### PR TITLE
Use Virt module in vlib library: breaks the test.

### DIFF
--- a/test/blackbox-tests/test-cases/melange/virtual_lib_compilation.t/vlib/vlib_impl.ml
+++ b/test/blackbox-tests/test-cases/melange/virtual_lib_compilation.t/vlib/vlib_impl.ml
@@ -1,1 +1,1 @@
-let hello = "Hello from "
+let hello = "Hello from " ^ Virt.t


### PR DESCRIPTION
Using the virtual module in `vlib` with melange breaks with:

```
File "vlib/vlib_impl.ml", line 1:  
Error: Virt not found, it means either the module does not exist or it is a namespace
```

The `ml` implementation works fine. 