### PR TITLE
melange: show that runtime_deps are copied to lib build folder

### DIFF
--- a/test/blackbox-tests/test-cases/melange/library-with-runtime-deps.t
+++ b/test/blackbox-tests/test-cases/melange/library-with-runtime-deps.t
@@ -43,6 +43,12 @@ Test `melange.runtime_deps` in a private library
   $ mkdir -p output/lib
   $ dune build @mel
 
+The runtime_dep index.txt was copied to the library build folder
+
+  $ ls _build/default/lib
+  foo.ml
+  index.txt
+
 The runtime_dep index.txt was copied to the build folder
 
   $ ls _build/default/output/lib


### PR DESCRIPTION
Showing behavior of runtime_deps.