### PR TITLE
melange: add test with rule eval in data-only dirs

### DIFF
--- a/test/blackbox-tests/test-cases/melange/evaluate-rules-in-data-only-dirs.t
+++ b/test/blackbox-tests/test-cases/melange/evaluate-rules-in-data-only-dirs.t
@@ -44,35 +44,6 @@ Full list of dirs
   Loading build directory _build/default/.output.mobjs/melange
   Loading build directory _build/default/.output.mobjs
   Loading build directory _build/default/.merlin-conf
-  Loading build directory _build/default/.bin
-  Loading build directory _build/default/.dune/ccomp
-  Loading build directory _build/default/.formatted
-  Loading build directory _build/default/.js
-  Loading build directory _build/default/.merlin-conf/.bin
-  Loading build directory _build/default/.merlin-conf/.formatted
-  Loading build directory _build/default/.merlin-conf/.utop
-  Loading build directory _build/default/.output.mobjs/.bin
-  Loading build directory _build/default/.output.mobjs/.formatted
-  Loading build directory _build/default/.output.mobjs/.utop
-  Loading build directory _build/default/.output.mobjs/melange/.bin
-  Loading build directory _build/default/.output.mobjs/melange/.formatted
-  Loading build directory _build/default/.output.mobjs/melange/.utop
-  Loading build directory _build/default/.ppx
-  Loading build directory _build/default/.topmod
-  Loading build directory _build/default/.utop
-  Loading build directory _build/default/.utop/.utop.eobjs
-  Loading build directory _build/default/.utop/.utop.eobjs/.bin
-  Loading build directory _build/default/.utop/.utop.eobjs/.formatted
-  Loading build directory _build/default/.utop/.utop.eobjs/.utop
-  Loading build directory _build/default/.utop/.utop.eobjs/byte
-  Loading build directory _build/default/.utop/.utop.eobjs/byte/.bin
-  Loading build directory _build/default/.utop/.utop.eobjs/byte/.formatted
-  Loading build directory _build/default/.utop/.utop.eobjs/byte/.utop
-  Loading build directory _build/default/.utop/.utop.eobjs/native
-  Loading build directory _build/default/.utop/.utop.eobjs/native/.bin
-  Loading build directory _build/default/.utop/.utop.eobjs/native/.formatted
-  Loading build directory _build/default/.utop/.utop.eobjs/native/.utop
-  Loading build directory _build/default/_doc
   Loading build directory _build/default/output/assets
   Loading build directory _build/default/assets
   Loading build directory _build/default/output/.bin

--- a/test/blackbox-tests/test-cases/melange/evaluate-rules-in-data-only-dirs.t
+++ b/test/blackbox-tests/test-cases/melange/evaluate-rules-in-data-only-dirs.t
@@ -1,0 +1,83 @@
+Test to show how data-only dirs are handled when evaluating rules
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.8)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (data_only_dirs assets)
+  > (melange.emit
+  >  (target output)
+  >  (alias mel)
+  >  (runtime_deps assets/file.txt))
+  > EOF
+
+  $ mkdir assets
+  $ cat > assets/file.txt <<EOF
+  > hello from file
+  > EOF
+
+  $ cat > main.ml <<EOF
+  > let dirname = [%bs.raw "__dirname"]
+  > let file_path = "./assets/file.txt"
+  > let file_content = Node.Fs.readFileSync (dirname ^ "/" ^ file_path) \`utf8
+  > let () = Js.log file_content
+  > EOF
+
+Dirs in data_only_dirs are visited
+
+  $ dune build @mel --debug-load-dir 2>&1 | grep assets
+  Loading build directory _build/default/output/assets
+  Loading build directory _build/default/assets
+  Loading build directory _build/default/output/assets/.bin
+  Loading build directory _build/default/output/assets/.formatted
+  Loading build directory _build/default/output/assets/.utop
+
+Full list of dirs
+
+  $ dune build @mel --debug-load-dir
+  Loading build directory _build/default
+  Loading build directory _build/default/.dune
+  Loading build directory _build
+  Loading build directory _build/default/output
+  Loading build directory _build/default/.output.mobjs/melange
+  Loading build directory _build/default/.output.mobjs
+  Loading build directory _build/default/.merlin-conf
+  Loading build directory _build/default/.bin
+  Loading build directory _build/default/.dune/ccomp
+  Loading build directory _build/default/.formatted
+  Loading build directory _build/default/.js
+  Loading build directory _build/default/.merlin-conf/.bin
+  Loading build directory _build/default/.merlin-conf/.formatted
+  Loading build directory _build/default/.merlin-conf/.utop
+  Loading build directory _build/default/.output.mobjs/.bin
+  Loading build directory _build/default/.output.mobjs/.formatted
+  Loading build directory _build/default/.output.mobjs/.utop
+  Loading build directory _build/default/.output.mobjs/melange/.bin
+  Loading build directory _build/default/.output.mobjs/melange/.formatted
+  Loading build directory _build/default/.output.mobjs/melange/.utop
+  Loading build directory _build/default/.ppx
+  Loading build directory _build/default/.topmod
+  Loading build directory _build/default/.utop
+  Loading build directory _build/default/.utop/.utop.eobjs
+  Loading build directory _build/default/.utop/.utop.eobjs/.bin
+  Loading build directory _build/default/.utop/.utop.eobjs/.formatted
+  Loading build directory _build/default/.utop/.utop.eobjs/.utop
+  Loading build directory _build/default/.utop/.utop.eobjs/byte
+  Loading build directory _build/default/.utop/.utop.eobjs/byte/.bin
+  Loading build directory _build/default/.utop/.utop.eobjs/byte/.formatted
+  Loading build directory _build/default/.utop/.utop.eobjs/byte/.utop
+  Loading build directory _build/default/.utop/.utop.eobjs/native
+  Loading build directory _build/default/.utop/.utop.eobjs/native/.bin
+  Loading build directory _build/default/.utop/.utop.eobjs/native/.formatted
+  Loading build directory _build/default/.utop/.utop.eobjs/native/.utop
+  Loading build directory _build/default/_doc
+  Loading build directory _build/default/output/assets
+  Loading build directory _build/default/assets
+  Loading build directory _build/default/output/.bin
+  Loading build directory _build/default/output/.formatted
+  Loading build directory _build/default/output/.utop
+  Loading build directory _build/default/output/assets/.bin
+  Loading build directory _build/default/output/assets/.formatted
+  Loading build directory _build/default/output/assets/.utop


### PR DESCRIPTION
Test to show which folders are visited when using `data_only_dirs`.