### PR TITLE
refactor: add compilation mode set

### DIFF
--- a/src/dune_lang/compilation_mode.ml
+++ b/src/dune_lang/compilation_mode.ml
@@ -4,11 +4,6 @@ type t =
   | Ocaml
   | Melange
 
-type modes =
-  { modes : t list
-  ; for_merlin : t
-  }
-
 let equal a b =
   match a, b with
   | Ocaml, Ocaml | Melange, Melange -> true
@@ -29,17 +24,35 @@ let repr =
 
 let to_dyn = Repr.to_dyn repr
 
+module Set = struct
+  type t =
+    { ocaml : bool
+    ; melange : bool
+    }
+
+  let of_lib_mode_set (modes : Lib_mode.Map.Set.t) =
+    { ocaml = modes.ocaml.byte || modes.ocaml.native; melange = modes.melange }
+  ;;
+
+  let to_list { ocaml; melange } =
+    match ocaml, melange with
+    | true, true -> [ Ocaml; Melange ]
+    | true, false -> [ Ocaml ]
+    | false, true -> [ Melange ]
+    | false, false -> []
+  ;;
+
+  let for_merlin { ocaml; melange } =
+    match ocaml, melange with
+    | true, _ -> Ocaml
+    | false, true -> Melange
+    | false, false -> Ocaml
+  ;;
+end
+
 let of_lib_mode = function
   | Lib_mode.Ocaml _ -> Ocaml
   | Melange -> Melange
-;;
-
-let of_mode_set (modes : Lib_mode.Map.Set.t) =
-  match modes.ocaml.byte, modes.ocaml.native, modes.melange with
-  | false, false, true -> { modes = [ Melange ]; for_merlin = Melange }
-  | true, _, false | _, true, false -> { modes = [ Ocaml ]; for_merlin = Ocaml }
-  | true, _, true | _, true, true -> { modes = [ Ocaml; Melange ]; for_merlin = Ocaml }
-  | false, false, false -> { modes = []; for_merlin = Ocaml }
 ;;
 
 let default_sandbox = function

--- a/src/dune_lang/compilation_mode.mli
+++ b/src/dune_lang/compilation_mode.mli
@@ -4,15 +4,17 @@ type t =
 
 val equal : t -> t -> bool
 val to_dyn : t -> Dyn.t
-
-type modes =
-  { modes : t list
-  ; for_merlin : t
-  }
-
 val of_lib_mode : Lib_mode.t -> t
-val of_mode_set : Lib_mode.Map.Set.t -> modes
 val default_sandbox : t -> Dune_engine.Sandbox_config.t
+
+module Set : sig
+  type mode := t
+  type t
+
+  val of_lib_mode_set : Lib_mode.Map.Set.t -> t
+  val to_list : t -> mode list
+  val for_merlin : t -> mode
+end
 
 module Per_mode : sig
   type mode := t

--- a/src/dune_rules/install_rules.ml
+++ b/src/dune_rules/install_rules.ml
@@ -247,8 +247,8 @@ end = struct
     in
     let lib_name = Library.best_name lib in
     let* installable_modules =
-      let lib_modes = Compilation_mode.of_mode_set lib_modes in
-      Memo.parallel_map lib_modes.modes ~f:(fun for_ ->
+      let lib_modes = Compilation_mode.Set.of_lib_mode_set lib_modes in
+      Memo.parallel_map (Compilation_mode.Set.to_list lib_modes) ~f:(fun for_ ->
         let+ modules =
           Dir_contents.ml dir_contents ~for_
           >>= Ml_sources.modules
@@ -833,8 +833,8 @@ end = struct
           and* modules =
             let* libs = Scope.DB.find_by_dir dir >>| Scope.libs in
             let+ modules =
-              let lib_modes = Compilation_mode.of_mode_set lib_modes in
-              Memo.parallel_map lib_modes.modes ~f:(fun for_ ->
+              let lib_modes = Compilation_mode.Set.of_lib_mode_set lib_modes in
+              Memo.parallel_map (Compilation_mode.Set.to_list lib_modes) ~f:(fun for_ ->
                 let+ modules =
                   Dir_contents.ml dir_contents ~for_
                   >>= Ml_sources.modules

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1464,8 +1464,8 @@ end = struct
         let instrumentation_backend =
           instrumentation_backend db.instrument_with resolve_forbid_ignore
         in
-        let modes = Compilation_mode.of_mode_set (Lib_info.modes info) in
-        Memo.parallel_map modes.modes ~f:(fun for_ ->
+        let modes = Compilation_mode.Set.of_lib_mode_set (Lib_info.modes info) in
+        Memo.parallel_map (Compilation_mode.Set.to_list modes) ~f:(fun for_ ->
           Lib_info.preprocess info ~for_
           |> Instrumentation.with_instrumentation ~instrumentation_backend
           >>| fun pps -> for_, Preprocess.Per_module.pps pps)

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -758,15 +758,16 @@ let rules (lib : Library.t) ~sctx ~dir_contents ~expander ~scope =
         ~lib_config
     in
     let merlin_ident = Merlin_ident.for_lib (Library.best_name lib) in
-    let* { Compilation_mode.modes; for_merlin } =
+    let* modes =
       let+ effective_modes =
         Lib_info.effective_modes
           lib_info
           ~melange_available:(Melange_binary.available sctx ~dir)
       in
-      Compilation_mode.of_mode_set effective_modes
+      Compilation_mode.Set.of_lib_mode_set effective_modes
     in
-    Memo.parallel_map modes ~f:(fun for_ ->
+    let for_merlin = Compilation_mode.Set.for_merlin modes in
+    Memo.parallel_map (Compilation_mode.Set.to_list modes) ~f:(fun for_ ->
       let buildable = lib.buildable in
       let libs = Scope.libs scope in
       let lib_id =

--- a/src/dune_rules/odoc/odoc.ml
+++ b/src/dune_rules/odoc/odoc.ml
@@ -696,8 +696,9 @@ let libs_of_pkg ctx ~pkg =
 
 let entry_modules_by_lib sctx lib =
   let info = Lib.Local.info lib in
-  let { Compilation_mode.for_merlin; _ } =
-    Compilation_mode.of_mode_set (Lib_info.modes info)
+  let for_merlin =
+    Compilation_mode.Set.of_lib_mode_set (Lib_info.modes info)
+    |> Compilation_mode.Set.for_merlin
   in
   Dir_contents.modules_of_local_lib sctx lib ~for_:for_merlin >>| Modules.entry_modules
 ;;
@@ -1234,9 +1235,9 @@ let gen_rules sctx ~dir rest =
          match lib with
          | Some lib ->
            let modes =
-             Lib_info.modes (Lib.Local.info lib) |> Compilation_mode.of_mode_set
+             Lib_info.modes (Lib.Local.info lib) |> Compilation_mode.Set.of_lib_mode_set
            in
-           modes.for_merlin
+           Compilation_mode.Set.for_merlin modes
          | None -> Ocaml
        in
        let+ () =
@@ -1274,9 +1275,9 @@ let gen_rules sctx ~dir rest =
          match lib with
          | Some lib ->
            let modes =
-             Lib_info.modes (Lib.Local.info lib) |> Compilation_mode.of_mode_set
+             Lib_info.modes (Lib.Local.info lib) |> Compilation_mode.Set.of_lib_mode_set
            in
-           modes.for_merlin
+           Compilation_mode.Set.for_merlin modes
          | None -> Ocaml
        in
        let+ () =

--- a/src/dune_rules/odoc/odoc_new.ml
+++ b/src/dune_rules/odoc/odoc_new.ml
@@ -371,7 +371,8 @@ module Classify = struct
              let pkg = Lib_name.package_name (Lib_info.name info) in
              (match
                 let for_ =
-                  (Compilation_mode.of_mode_set (Lib_info.modes info)).for_merlin
+                  Compilation_mode.Set.of_lib_mode_set (Lib_info.modes info)
+                  |> Compilation_mode.Set.for_merlin
                 in
                 let mods_opt = Lib_info.modules ~for_ info in
                 mods_opt, Lib_info.entry_modules info ~for_
@@ -443,8 +444,8 @@ module Valid = struct
                 let* acc = acc in
                 let+ libs =
                   let for_ =
-                    (Compilation_mode.of_mode_set (Lib_info.modes (Lib.info lib)))
-                      .for_merlin
+                    Compilation_mode.Set.of_lib_mode_set (Lib_info.modes (Lib.info lib))
+                    |> Compilation_mode.Set.for_merlin
                   in
                   let* libs =
                     Lib.closure (lib :: Option.to_list stdlib) ~linking:false ~for_
@@ -919,7 +920,8 @@ let compile_requires stdlib_opt libs =
   Memo.List.map
     ~f:(fun l ->
       let for_ =
-        (Compilation_mode.of_mode_set (Lib_info.modes (Lib.info l))).for_merlin
+        Compilation_mode.Set.of_lib_mode_set (Lib_info.modes (Lib.info l))
+        |> Compilation_mode.Set.for_merlin
       in
       Lib.closure ~linking:false [ l ] ~for_)
     libs
@@ -1234,7 +1236,7 @@ let lib_artifacts ctx all index lib modules =
   let cm_kind : Lib_mode.Cm_kind.t =
     match
       let modes = Lib_info.modes info in
-      (Compilation_mode.of_mode_set modes).for_merlin
+      Compilation_mode.Set.of_lib_mode_set modes |> Compilation_mode.Set.for_merlin
     with
     | Ocaml -> Ocaml Cmi
     | Melange -> Melange Cmi
@@ -1511,8 +1513,9 @@ let index_info_of_lib_def =
     in
     let info = Lib.info lib in
     let+ artifacts =
-      let { Compilation_mode.for_merlin; _ } =
-        Compilation_mode.of_mode_set (Lib_info.modes info)
+      let for_merlin =
+        Compilation_mode.Set.of_lib_mode_set (Lib_info.modes info)
+        |> Compilation_mode.Set.for_merlin
       in
       let+ modules = Dir_contents.modules_of_lib sctx (lib :> Lib.t) ~for_:for_merlin in
       match modules with


### PR DESCRIPTION
Introduce `Compilation_mode.Set` and migrate existing plural compilation mode call sites to use it.

Based on `ocaml/main`.