### PR TITLE
perf(source): avoid memo branches for ordinary files

### DIFF
--- a/bench/micro/dune
+++ b/bench/micro/dune
@@ -55,3 +55,24 @@
  (allow_overlapping_dependencies)
  (modules path_bench_main)
  (libraries path_bench core_bench.inline_benchmarks))
+
+(library
+ (name source_dir_scan_bench)
+ (modules source_dir_scan_bench)
+ (library_flags -linkall)
+ (preprocess
+  (pps ppx_bench))
+ (libraries
+  dune_engine
+  fiber
+  memo
+  source
+  stdune
+  unix
+  core_bench.inline_benchmarks))
+
+(executable
+ (name source_dir_scan_bench_main)
+ (allow_overlapping_dependencies)
+ (modules source_dir_scan_bench_main)
+ (libraries source_dir_scan_bench core_bench.inline_benchmarks))

--- a/bench/micro/runner.sh
+++ b/bench/micro/runner.sh
@@ -7,6 +7,7 @@ declare -A benchmarks=(
   [thread_pool]="thread_pool_bench:thread_pool_bench_main"
   [digest]="digest_bench:digest_bench_main"
   [path]="path_bench:path_bench_main"
+  [source_dir_scan]="source_dir_scan_bench:source_dir_scan_bench_main"
 )
 
 if [[ -z "${benchmarks[$1]}" ]]; then

--- a/bench/micro/source_dir_scan_bench.ml
+++ b/bench/micro/source_dir_scan_bench.ml
@@ -1,0 +1,58 @@
+open Stdune
+module Dir_contents = Source.Dir_contents
+
+let () =
+  Path.Build.set_build_dir (In_source_dir Path.Source.(relative root "_build"));
+  ignore (Dune_engine.Fs_memo.init ~dune_file_watcher:None : Memo.Invalidation.t)
+;;
+
+let run memo =
+  Memo.reset Memo.Invalidation.empty;
+  Fiber.run (Memo.run memo) ~iter:(fun () -> failwith "deadlock")
+;;
+
+let file_name i = Printf.sprintf "file-%05d" i
+
+let create_file path =
+  let fd = Unix.openfile path [ O_WRONLY; O_CREAT; O_EXCL ] 0o600 in
+  Unix.close fd
+;;
+
+let create_fixture file_count =
+  let basename =
+    Printf.sprintf ".source-dir-scan-bench-%d-%d" (Unix.getpid ()) file_count
+  in
+  let dirname = Filename.concat (Sys.getcwd ()) basename in
+  Unix.mkdir dirname 0o700;
+  for i = 1 to file_count do
+    create_file (Filename.concat dirname (file_name i))
+  done;
+  Stdlib.at_exit (fun () ->
+    for i = 1 to file_count do
+      Unix.unlink (Filename.concat dirname (file_name i))
+    done;
+    Unix.rmdir dirname);
+  let path = Path.Source.relative Path.Source.root basename in
+  let scan () =
+    match run (Dir_contents.For_benchmarks.of_source_path path) with
+    | Error _ -> failwith "unable to scan benchmark fixture"
+    | Ok contents -> contents
+  in
+  let contents = scan () in
+  let scanned_file_count =
+    Dir_contents.files contents |> Filename.Array.Set.to_list |> List.length
+  in
+  if scanned_file_count <> file_count
+  then
+    failwith
+      (Printf.sprintf
+         "expected %d files in benchmark fixture, got %d"
+         file_count
+         scanned_file_count);
+  scan
+;;
+
+let%bench_fun ("ordinary files" [@indexed file_count = [ 100; 1_000; 10_000 ]]) =
+  let scan = create_fixture file_count in
+  fun () -> ignore (scan () : Dir_contents.t)
+;;

--- a/bench/micro/source_dir_scan_bench_main.ml
+++ b/bench/micro/source_dir_scan_bench_main.ml
@@ -1,0 +1,1 @@
+Inline_benchmarks_public.Runner.main ~libname:"source_dir_scan_bench"

--- a/src/source/dir_contents.ml
+++ b/src/source/dir_contents.ml
@@ -95,35 +95,47 @@ let of_source_path_impl path =
       ];
     Memo.return (Error unix_error)
   | Ok dir_contents ->
-    let+ files, dirs =
+    let files, dirs_to_scan =
       Fs_memo.Dir_contents.to_list dir_contents
-      |> Memo.parallel_map ~f:(fun (fn, (kind : File_kind.t)) ->
+      |> List.filter_partition_map ~f:(fun (fn, (kind : File_kind.t)) ->
         let path = Path.Source.relative_fname path fn in
         if is_special kind || Path.Source.is_in_build_dir path || is_temp_file fn
-        then Memo.return List.Skip
-        else
-          let+ is_directory, file =
-            match kind with
-            | S_DIR ->
-              let+ file =
-                File.of_source_path path
-                >>| function
-                | Ok file -> file
-                | Error _ -> File.dummy
-              in
-              true, file
-            | S_LNK ->
-              Fs_memo.path_stat (In_source_dir path)
-              >>| (function
-               | Ok ({ st_kind = S_DIR; _ } as st) -> true, File.of_stats st
-               | Ok _ | Error _ -> false, File.dummy)
-            | _ -> Memo.return (false, File.dummy)
-          in
-          if is_directory then List.Right (fn, file) else Left fn)
-      >>| List.filter_partition_map ~f:Fun.id
+        then List.Skip
+        else (
+          match kind with
+          | S_DIR -> List.Right (`Directory (fn, path))
+          | S_LNK -> List.Right (`Symlink (fn, path))
+          | _ -> List.Left fn))
+    in
+    let+ symlink_files, dirs =
+      match dirs_to_scan with
+      | [] -> Memo.return ([], [])
+      | dirs_to_scan ->
+        Memo.parallel_map dirs_to_scan ~f:(function
+          | `Directory (fn, path) ->
+            let+ file =
+              File.of_source_path path
+              >>| function
+              | Ok file -> file
+              | Error _ -> File.dummy
+            in
+            List.Right (fn, file)
+          | `Symlink (fn, path) ->
+            Fs_memo.path_stat (In_source_dir path)
+            >>| (function
+             | Ok ({ st_kind = S_DIR; _ } as st) -> List.Right (fn, File.of_stats st)
+             | Ok _ | Error _ -> List.Left fn))
+        >>| List.filter_partition_map ~f:Fun.id
+    in
+    let files = Filename.Array.Set.of_sorted_list files in
+    let files =
+      match symlink_files with
+      | [] -> files
+      | symlink_files ->
+        Filename.Array.Set.union files (Filename.Array.Set.of_sorted_list symlink_files)
     in
     let dirs = Filename.Array.Map.of_list_exn dirs in
-    { files = Filename.Array.Set.of_list files; dirs } |> Result.ok
+    { files; dirs } |> Result.ok
 ;;
 
 (* Having a cutoff here speeds up incremental rebuilds quite a bit when a

--- a/src/source/dir_contents.ml
+++ b/src/source/dir_contents.ml
@@ -137,3 +137,7 @@ let of_source_path_memo =
 ;;
 
 let of_source_path = Memo.exec of_source_path_memo
+
+module For_benchmarks = struct
+  let of_source_path = of_source_path_impl
+end

--- a/src/source/dir_contents.mli
+++ b/src/source/dir_contents.mli
@@ -16,3 +16,7 @@ val dirs : t -> File.t Filename.Array.Map.t
 val files : t -> Filename.Array.Set.t
 val to_dyn : t -> Dyn.t
 val of_source_path : Path.Source.t -> (t, Unix_error.Detailed.t) result Memo.t
+
+module For_benchmarks : sig
+  val of_source_path : Path.Source.t -> (t, Unix_error.Detailed.t) result Memo.t
+end

--- a/src/source/source.ml
+++ b/src/source/source.ml
@@ -1,4 +1,5 @@
 module Source_dir_status = Source_dir_status
+module Dir_contents = Dir_contents
 module Dune_file = Dune_file
 module Include_stanza = Include_stanza
 module Source_tree = Source_tree

--- a/test/expect-tests/dune
+++ b/test/expect-tests/dune
@@ -9,6 +9,7 @@
   dune_scheduler
   dune_threaded_console
   dune_rules
+  source
   fiber
   dune_lang
   ocaml

--- a/test/expect-tests/source_dir_contents_tests.ml
+++ b/test/expect-tests/source_dir_contents_tests.ml
@@ -1,0 +1,48 @@
+open Stdune
+module Dir_contents = Source.Dir_contents
+
+let () =
+  Dune_tests_common.init ();
+  ignore (Dune_engine.Fs_memo.init ~dune_file_watcher:None : Memo.Invalidation.t)
+;;
+
+let run memo =
+  Memo.reset Memo.Invalidation.empty;
+  Fiber.run (Memo.run memo) ~iter:(fun () -> failwith "deadlock")
+;;
+
+let print_filenames label filenames =
+  let filenames =
+    Filename.Array.Set.to_list filenames |> List.map ~f:Filename.to_string
+  in
+  Printf.printf "%s: %s\n" label (String.concat filenames ~sep:", ")
+;;
+
+let%expect_test "mixed directory entries" =
+  Temp.with_temp_dir
+    ~parent_dir:Path.root
+    ~prefix:"source-dir-contents"
+    ~suffix:""
+    ~f:(fun dir ->
+      let dir = Result.ok_exn dir in
+      Io.write_file (Path.relative dir "a.ml") "";
+      Io.write_file (Path.relative dir ".#lock") "";
+      Io.write_file (Path.relative dir "ignored.swp") "";
+      Io.write_file (Path.relative dir "ignored~") "";
+      Path.mkdir_p (Path.relative dir "dir");
+      Unix.symlink "a.ml" (Path.to_string (Path.relative dir "file-link"));
+      Unix.symlink "dir" (Path.to_string (Path.relative dir "dir-link"));
+      Unix.symlink "missing" (Path.to_string (Path.relative dir "broken-link"));
+      let path = Path.as_in_source_tree_exn dir in
+      let contents =
+        match run (Dir_contents.of_source_path path) with
+        | Ok contents -> contents
+        | Error _ -> failwith "unable to scan test directory"
+      in
+      print_filenames "files" (Dir_contents.files contents);
+      print_filenames "dirs" (Filename.Array.Map.keys (Dir_contents.dirs contents)));
+  [%expect
+    {|
+    files: a.ml, broken-link, file-link
+    dirs: dir, dir-link |}]
+;;


### PR DESCRIPTION
Partition ordinary source files synchronously and create Memo branches only for directories and symlinks.\n\nOn current ocaml/main, 1,000-file scans fall from 260.00 us to 105.62 us and 10,000-file scans from 3.365 ms to 1.809 ms; minor allocations fall by 53-56%.\n\nRebased over the compact directory representation from ocaml/dune#15658.