### PR TITLE
fix: rebuild virtual-library object maps after mapping

### DIFF
--- a/src/dune_rules/modules.ml
+++ b/src/dune_rules/modules.ml
@@ -1287,11 +1287,13 @@ module With_vlib = struct
     match t with
     | Modules modules -> Modules (map_user_available ~f modules)
     | Impl impl ->
-      Impl
+      let impl =
         { impl with
           impl = map_user_available ~f impl.impl
         ; vlib = map_user_available ~f impl.vlib
         }
+      in
+      with_obj_map (Impl impl)
   ;;
 
   type split_by_lib =

--- a/test/expect-tests/module_tests.ml
+++ b/test/expect-tests/module_tests.ml
@@ -200,7 +200,7 @@ let%expect_test "virtual-library object map after mapping" =
       Code_error.raise "expected a virtual-library implementation" [])
   |> Dyn.list Dyn.string
   |> Dune_tests_common.print_dyn;
-  [%expect {| [ "shared -> intf:shared impl:shared" ] |}]
+  [%expect {| [ "mapped__shared -> intf:mapped__shared impl:mapped__shared" ] |}]
 ;;
 
 let%expect_test "qualified-group dependency lookup" =


### PR DESCRIPTION
Rebuild the combined virtual-library object map after mapping its modules.

Fixes the behavior covered by ocaml/dune#15865. For review only; not submitted upstream.