### PR TITLE
refactor(melange): reuse object dirs for emission includes

### DIFF
--- a/bench/micro/memo_bench/benchmarks.ml
+++ b/bench/micro/memo_bench/benchmarks.ml
@@ -21,7 +21,7 @@ module Memo = struct
   ;;
 
   let memoize t =
-    let l = Memo.lazy_ ~cutoff:(fun _ _ -> false) (fun () -> t) in
+    let l = Memo.lazy_ ~name:"memoize" ~cutoff:(fun _ _ -> false) (fun () -> t) in
     Memo.of_thunk (fun () -> Memo.Lazy.force l)
   ;;
 
@@ -43,7 +43,11 @@ module Var = struct
   let create value =
     let value = ref value in
     { value
-    ; cell = Memo.lazy_node ~cutoff:(fun _ _ -> false) (fun () -> Memo.return !value)
+    ; cell =
+        Memo.lazy_node
+          ~name:"var"
+          ~cutoff:(fun _ _ -> false)
+          (fun () -> Memo.return !value)
     }
   ;;
 

--- a/bench/micro/memo_bench/memo_tests_env.ml
+++ b/bench/micro/memo_bench/memo_tests_env.ml
@@ -43,7 +43,7 @@ module Memo = struct
   let of_io f = Memo.of_reproducible_fiber (Fiber.of_thunk f)
 
   let memoize t =
-    let l = Memo.lazy_ ~cutoff:(fun _ _ -> false) (fun () -> t) in
+    let l = Memo.lazy_ ~name:"memoize" ~cutoff:(fun _ _ -> false) (fun () -> t) in
     Memo.of_thunk (fun () -> Memo.Lazy.force l)
   ;;
 
@@ -56,7 +56,9 @@ module Memo = struct
   module Glass = struct
     type t = (unit, unit) Memo.Node.t
 
-    let create () = Memo.lazy_node ~cutoff:(fun _ _ -> false) (fun () -> Memo.return ())
+    let create () =
+      Memo.lazy_node ~name:"glass" ~cutoff:(fun _ _ -> false) (fun () -> Memo.return ())
+    ;;
 
     let break (t : t) =
       invalidation_acc
@@ -104,7 +106,11 @@ module Var = struct
   let create value =
     let value = ref value in
     { value
-    ; cell = Memo.lazy_node ~cutoff:(fun _ _ -> false) (fun () -> Memo.return !value)
+    ; cell =
+        Memo.lazy_node
+          ~name:"var"
+          ~cutoff:(fun _ _ -> false)
+          (fun () -> Memo.return !value)
     }
   ;;
 

--- a/boot/bootstrap.ml
+++ b/boot/bootstrap.ml
@@ -127,7 +127,7 @@ let () =
       let ocamllex = Filename.concat bin_dir "ocamllex" in
       compiler, ocamllex, Some "--secondary", Some lib_dir)
   in
-  exit_if_non_zero (runf "%s -q -o %s %s" ocamllex (pps ^ ".ml") (pps ^ ".mll"));
+  exit_if_non_zero (runf "%s -ml -q -o %s %s" ocamllex (pps ^ ".ml") (pps ^ ".mll"));
   let script =
     let fname, out = Filename.open_temp_file duneboot "main" in
     script out;

--- a/boot/duneboot.ml
+++ b/boot/duneboot.ml
@@ -1139,7 +1139,7 @@ let insert_header fn ~header =
 
 let copy_lexer ~header src dst =
   let dst = Filename.remove_extension dst ^ ".ml" in
-  let+ () = Process.run Config.ocamllex [ "-q"; "-o"; dst; src ] in
+  let+ () = Process.run Config.ocamllex [ "-ml"; "-q"; "-o"; dst; src ] in
   insert_header dst ~header
 ;;
 

--- a/doc/changes/added/15923.md
+++ b/doc/changes/added/15923.md
@@ -1,0 +1,3 @@
+- Added an opt-in `sat` trace category emitting a `sat/solve` event with
+  the SAT solver's stats (variables, clauses, decisions, conflicts) and
+  duration. Enable with `DUNE_TRACE=+sat`. (#15923, @Alizter)

--- a/doc/changes/fixed/15949.md
+++ b/doc/changes/fixed/15949.md
@@ -1,0 +1,3 @@
+- Fix Melange emission with installed libraries whose `.cmj` and `.cmi` files
+  are stored in the `melange` object directory (#15949, fixes #14820,
+  @anmonteiro)

--- a/otherlibs/stdune/src/filename.ml
+++ b/otherlibs/stdune/src/filename.ml
@@ -20,9 +20,9 @@ let is_valid s =
 let of_string s = Option.some_if (is_valid s) s
 
 let of_string_exn s =
-  match of_string s with
-  | Some t -> t
-  | None ->
+  if is_valid s
+  then s
+  else
     Code_error.raise
       "Filename.of_string_exn: invalid filename"
       [ "filename", Dyn.string s ]
@@ -90,9 +90,9 @@ module Extension = struct
   let of_string s = Option.some_if (is_valid s) s
 
   let of_string_exn s =
-    match of_string s with
-    | Some t -> t
-    | None ->
+    if is_valid s
+    then s
+    else
       Code_error.raise
         "Filename.Extension.of_string_exn: invalid extension"
         [ "extension", Dyn.string s ]

--- a/otherlibs/stdune/src/hashtbl.ml
+++ b/otherlibs/stdune/src/hashtbl.ml
@@ -28,6 +28,19 @@ struct
       x
   ;;
 
+  let dedupe_by ~key =
+    let seen = create 32 in
+    Staged.stage (fun list ->
+      clear seen;
+      List.filter list ~f:(fun x ->
+        let key = key x in
+        if mem seen key
+        then false
+        else (
+          set seen key ();
+          true)))
+  ;;
+
   let foldi t ~init ~f = fold t ~init ~f:(fun ~key ~data acc -> f key data acc)
   let fold t ~init ~f = foldi t ~init ~f:(fun _ x -> f x)
 

--- a/otherlibs/stdune/src/hashtbl_intf.ml
+++ b/otherlibs/stdune/src/hashtbl_intf.ml
@@ -15,6 +15,13 @@ module type S = sig
   val find : 'a t -> key -> 'a option
   val find_exn : 'a t -> key -> 'a
   val find_or_add : 'a t -> key -> f:(key -> 'a) -> 'a
+
+  (** [dedupe_by ~key] returns a staged function that removes elements with
+      duplicate keys from a list while preserving the first occurrence of every
+      key. Unstage the function once and reuse it. It reuses a mutable table and
+      must not be called concurrently or reentrantly. *)
+  val dedupe_by : key:('a -> key) -> ('a list -> 'a list) Staged.t
+
   val fold : 'a t -> init:'b -> f:('a -> 'b -> 'b) -> 'b
   val foldi : 'a t -> init:'b -> f:(key -> 'a -> 'b -> 'b) -> 'b
   val of_list_exn : (key * 'a) list -> 'a t

--- a/otherlibs/stdune/src/path0.ml
+++ b/otherlibs/stdune/src/path0.ml
@@ -76,11 +76,11 @@ module Local_gen = struct
     let relative_result t components =
       let rec loop t components =
         match components with
-        | [] -> Result.Ok t
+        | [] -> Ok t
         | "." :: rest -> loop t rest
         | ".." :: rest ->
           (match parent t with
-           | None -> Result.Error `Outside_the_workspace
+           | None -> Error `Outside_the_workspace
            | Some parent -> loop parent rest)
         | fn :: rest ->
           if is_root t
@@ -162,23 +162,31 @@ module Local_gen = struct
     in
     fun s ->
       let len = String.length s in
-      len = 0 || before_slash s (len - 1)
+      len > 0 && before_slash s (len - 1)
   ;;
 
+  let is_valid s = is_root s || is_canonicalized s
+
   let parse_string_result s =
-    match s with
-    | "" | "." -> Result.Ok root
-    | _ when is_canonicalized s -> Result.Ok s
-    | _ -> relative_result root s
+    if is_valid s
+    then Ok s
+    else if String.is_empty s
+    then Ok root
+    else relative_result root s
   ;;
 
   let parse_string_exn s =
-    match parse_string_result s with
-    | Ok t -> t
-    | Error `Outside_the_workspace ->
-      Code_error.raise
-        "Local.parse_string_exn: path outside the workspace"
-        [ "s", String s ]
+    if is_valid s
+    then s
+    else if String.is_empty s
+    then root
+    else (
+      match relative_result root s with
+      | Ok t -> t
+      | Error `Outside_the_workspace ->
+        Code_error.raise
+          "Local.parse_string_exn: path outside the workspace"
+          [ "s", String s ])
   ;;
 
   let of_string s = parse_string_exn s

--- a/otherlibs/stdune/test/path_tests.ml
+++ b/otherlibs/stdune/test/path_tests.ml
@@ -29,6 +29,17 @@ let external_basename s =
   | exception Code_error.E _ -> print_endline "invalid"
 ;;
 
+let local_of_string s =
+  match Path.Local.of_string s with
+  | path ->
+    printfn
+      "%S -> %S%s"
+      s
+      (Path.Local.to_string path)
+      (if Path.Local.is_root path then " (root)" else "")
+  | exception User_error.E _ -> printfn "%S -> outside workspace" s
+;;
+
 let descendant p ~of_ = Dyn.option Path.to_dyn (Path.descendant p ~of_) |> print_dyn
 let is_descendant p ~of_ = Dyn.bool (Path.is_descendant p ~of_) |> print_dyn
 
@@ -50,6 +61,37 @@ let drop_build_context p =
 ;;
 
 let local_part p = Path.local_part p |> Path.Local.to_dyn |> print_dyn
+
+let%expect_test "local path parsing produces canonical representations" =
+  List.iter
+    [ ""
+    ; "."
+    ; "foo"
+    ; "foo/bar"
+    ; "./foo"
+    ; "foo/./bar"
+    ; "foo//bar/"
+    ; "foo/../bar"
+    ; "foo/.."
+    ; ".."
+    ; "../foo"
+    ]
+    ~f:local_of_string;
+  [%expect
+    {|
+    "" -> "." (root)
+    "." -> "." (root)
+    "foo" -> "foo"
+    "foo/bar" -> "foo/bar"
+    "./foo" -> "foo"
+    "foo/./bar" -> "foo/bar"
+    "foo//bar/" -> "foo/bar"
+    "foo/../bar" -> "bar"
+    "foo/.." -> "." (root)
+    ".." -> outside workspace
+    "../foo" -> outside workspace
+    |}]
+;;
 
 let%expect_test _ =
   let p = Path.(relative root) "foo" in

--- a/otherlibs/stdune/test/string_tests.ml
+++ b/otherlibs/stdune/test/string_tests.ml
@@ -219,3 +219,17 @@ let%expect_test "split_lines preserves carriage returns outside CRLF" =
     [ "first"; "second" ]
     |}]
 ;;
+
+let%expect_test "table dedupe_by preserves first occurrences across calls" =
+  let dedupe = String.Table.dedupe_by ~key:fst |> Staged.unstage in
+  let print values = dedupe values |> list (pair string int) |> print_dyn in
+  print [];
+  print [ "a", 1; "b", 2; "a", 3; "c", 4; "b", 5 ];
+  print [ "c", 6; "a", 7; "c", 8 ];
+  [%expect
+    {|
+    []
+    [ ("a", 1); ("b", 2); ("c", 4) ]
+    [ ("c", 6); ("a", 7) ]
+    |}]
+;;

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -231,6 +231,18 @@ let feed_int_and_bool hasher scratch i b =
   feed_bytes_raw hasher scratch ~len:9
 ;;
 
+let feed_string_raw_and_bool hasher scratch string bool =
+  let length = String.length string in
+  if length < Bytes.length scratch
+  then (
+    Bytes.unsafe_blit_string ~src:string ~src_pos:0 ~dst:scratch ~dst_pos:0 ~len:length;
+    Bytes.set scratch length (if bool then '\001' else '\000');
+    feed_bytes_raw hasher scratch ~len:(length + 1))
+  else (
+    feed_string_raw hasher string;
+    feed_bool hasher scratch bool)
+;;
+
 let rec feed_repr : type a. Hasher.t -> Bytes.t -> a Repr.t -> a -> unit =
   fun hasher scratch repr value ->
   match repr with
@@ -308,15 +320,13 @@ and feed_repr_cases : type a. Hasher.t -> Bytes.t -> a Repr.case list -> a -> un
     if test value
     then (
       feed_int_and_int hasher scratch 11 (String.length tag);
-      feed_string_raw hasher tag;
-      feed_bool hasher scratch false)
+      feed_string_raw_and_bool hasher scratch tag false)
     else feed_repr_cases hasher scratch rest value
   | Repr.Case1 { tag; repr; proj } :: rest ->
     (match proj value with
      | Some argument ->
        feed_int_and_int hasher scratch 11 (String.length tag);
-       feed_string_raw hasher tag;
-       feed_bool hasher scratch true;
+       feed_string_raw_and_bool hasher scratch tag true;
        feed_repr hasher scratch repr argument
      | None -> feed_repr_cases hasher scratch rest value)
 ;;

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -395,6 +395,13 @@ module Manual = struct
   let int () = Hasher.feed_manual_int
   let string () s = Hasher.feed_manual_sized_string s
 
+  let string_with_separator () left ~separator right =
+    int () (String.length left + String.length separator + String.length right);
+    Hasher.feed_manual_string left;
+    Hasher.feed_manual_string separator;
+    Hasher.feed_manual_string right
+  ;;
+
   let option t ~f = function
     | None -> bool t false
     | Some x ->

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -200,11 +200,6 @@ let feed_bytes_raw hasher bytes ~len =
   Blake3_mini.feed_string hasher (Bytes.unsafe_to_string bytes) ~pos:0 ~len
 ;;
 
-let feed_int64 hasher scratch i =
-  Stdlib.Bytes.set_int64_le scratch 0 i;
-  feed_bytes_raw hasher scratch ~len:8
-;;
-
 let feed_bool hasher scratch b =
   Bytes.set scratch 0 (if b then '\001' else '\000');
   feed_bytes_raw hasher scratch ~len:1
@@ -220,54 +215,50 @@ let feed_string hasher scratch s =
   feed_string_raw hasher s
 ;;
 
+let feed_int_and_int64 hasher scratch first second =
+  Stdlib.Bytes.set_int64_le scratch 0 (Int64.of_int first);
+  Stdlib.Bytes.set_int64_le scratch 8 second;
+  feed_bytes_raw hasher scratch ~len:16
+;;
+
+let feed_int_and_int hasher scratch first second =
+  feed_int_and_int64 hasher scratch first (Int64.of_int second)
+;;
+
+let feed_int_and_bool hasher scratch i b =
+  Stdlib.Bytes.set_int64_le scratch 0 (Int64.of_int i);
+  Bytes.set scratch 8 (if b then '\001' else '\000');
+  feed_bytes_raw hasher scratch ~len:9
+;;
+
 let rec feed_repr : type a. Hasher.t -> Bytes.t -> a Repr.t -> a -> unit =
   fun hasher scratch repr value ->
   match repr with
-  | Unit ->
-    feed_int hasher scratch 1;
-    feed_bool hasher scratch false
-  | Bool ->
-    feed_int hasher scratch 2;
-    feed_bool hasher scratch value
-  | Int ->
-    feed_int hasher scratch 3;
-    feed_int hasher scratch value
+  | Unit -> feed_int_and_bool hasher scratch 1 false
+  | Bool -> feed_int_and_bool hasher scratch 2 value
+  | Int -> feed_int_and_int hasher scratch 3 value
   | String ->
-    feed_int hasher scratch 4;
-    feed_string hasher scratch value
-  | Int32 ->
-    feed_int hasher scratch 12;
-    feed_int64 hasher scratch (Int64.of_int32 value)
-  | Int64 ->
-    feed_int hasher scratch 13;
-    feed_int64 hasher scratch value
-  | Nativeint ->
-    feed_int hasher scratch 14;
-    feed_int64 hasher scratch (Int64.of_nativeint value)
+    feed_int_and_int hasher scratch 4 (String.length value);
+    feed_string_raw hasher value
+  | Int32 -> feed_int_and_int64 hasher scratch 12 (Int64.of_int32 value)
+  | Int64 -> feed_int_and_int64 hasher scratch 13 value
+  | Nativeint -> feed_int_and_int64 hasher scratch 14 (Int64.of_nativeint value)
   | Bytes ->
-    feed_int hasher scratch 15;
-    feed_int hasher scratch (Bytes.length value);
+    feed_int_and_int hasher scratch 15 (Bytes.length value);
     feed_bytes_raw hasher value ~len:(Bytes.length value)
-  | Char ->
-    feed_int hasher scratch 16;
-    feed_int hasher scratch (Char.code value)
-  | Float ->
-    feed_int hasher scratch 17;
-    feed_int64 hasher scratch (Int64.bits_of_float value)
+  | Char -> feed_int_and_int hasher scratch 16 (Char.code value)
+  | Float -> feed_int_and_int64 hasher scratch 17 (Int64.bits_of_float value)
   | Option repr ->
-    feed_int hasher scratch 5;
     (match value with
-     | None -> feed_bool hasher scratch false
+     | None -> feed_int_and_bool hasher scratch 5 false
      | Some x ->
-       feed_bool hasher scratch true;
+       feed_int_and_bool hasher scratch 5 true;
        feed_repr hasher scratch repr x)
   | List repr ->
-    feed_int hasher scratch 6;
-    feed_int hasher scratch (List.length value);
+    feed_int_and_int hasher scratch 6 (List.length value);
     List.iter value ~f:(feed_repr hasher scratch repr)
   | Array repr ->
-    feed_int hasher scratch 7;
-    feed_int hasher scratch (Array.length value);
+    feed_int_and_int hasher scratch 7 (Array.length value);
     Array.iter value ~f:(feed_repr hasher scratch repr)
   | Pair (left, right) ->
     feed_int hasher scratch 8;
@@ -342,7 +333,7 @@ module Feed = struct
 
   let bool = contramap string ~f:Bool.to_string
   let int = contramap string ~f:Int.to_string
-  let repr repr hasher value = feed_repr hasher (Bytes.create 8) repr value
+  let repr repr hasher value = feed_repr hasher (Bytes.create 16) repr value
 
   let list feed_x hasher xs =
     int hasher (List.length xs);

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -282,9 +282,7 @@ let rec feed_repr : type a. Hasher.t -> Bytes.t -> a Repr.t -> a -> unit =
   | Record (_, fields) ->
     feed_int hasher scratch 10;
     feed_repr_fields hasher scratch fields value
-  | Variant (_, cases) ->
-    feed_int hasher scratch 11;
-    feed_repr_cases hasher scratch cases value
+  | Variant (_, cases) -> feed_repr_cases hasher scratch cases value
   | View { repr; to_ } -> feed_repr hasher scratch repr (to_ value)
   | Abstract _ ->
     Code_error.raise
@@ -302,19 +300,22 @@ and feed_repr_cases : type a. Hasher.t -> Bytes.t -> a Repr.case list -> a -> un
   fun hasher scratch cases value ->
   match cases with
   | [] ->
+    feed_int hasher scratch 11;
     Code_error.raise
       "Repr.variant: value did not match any case"
       [ "value", Dyn.string "<opaque>" ]
   | Repr.Case0 { tag; test } :: rest ->
     if test value
     then (
-      feed_string hasher scratch tag;
+      feed_int_and_int hasher scratch 11 (String.length tag);
+      feed_string_raw hasher tag;
       feed_bool hasher scratch false)
     else feed_repr_cases hasher scratch rest value
   | Repr.Case1 { tag; repr; proj } :: rest ->
     (match proj value with
      | Some argument ->
-       feed_string hasher scratch tag;
+       feed_int_and_int hasher scratch 11 (String.length tag);
+       feed_string_raw hasher tag;
        feed_bool hasher scratch true;
        feed_repr hasher scratch repr argument
      | None -> feed_repr_cases hasher scratch rest value)

--- a/src/dune_digest/digest.ml
+++ b/src/dune_digest/digest.ml
@@ -63,6 +63,24 @@ module Hasher = struct
     Scratch.pos := pos + 8
   ;;
 
+  let feed_manual_sized_string s =
+    let length = String.length s in
+    let pos = !Scratch.pos in
+    if length <= Scratch.len - pos - 8
+    then (
+      Stdlib.Bytes.set_int64_le Scratch.buf pos (Int64.of_int length);
+      Bytes.unsafe_blit_string
+        ~src:s
+        ~src_pos:0
+        ~dst:Scratch.buf
+        ~dst_pos:(pos + 8)
+        ~len:length;
+      Scratch.pos := pos + 8 + length)
+    else (
+      feed_manual_int length;
+      feed_manual_string s)
+  ;;
+
   let feed_manual_bool b =
     let pos = !Scratch.pos in
     let pos =
@@ -375,11 +393,7 @@ module Manual = struct
   let create () = ()
   let bool () = Hasher.feed_manual_bool
   let int () = Hasher.feed_manual_int
-
-  let string () s =
-    int () (String.length s);
-    Hasher.feed_manual_string s
-  ;;
+  let string () s = Hasher.feed_manual_sized_string s
 
   let option t ~f = function
     | None -> bool t false

--- a/src/dune_digest/digest.mli
+++ b/src/dune_digest/digest.mli
@@ -39,6 +39,11 @@ module Manual : sig
   val bool : t -> bool -> unit
   val int : t -> int -> unit
   val string : t -> string -> unit
+
+  (** Feed the same representation as [string t (left ^ separator ^ right)]
+      without constructing the concatenated string. *)
+  val string_with_separator : t -> string -> separator:string -> string -> unit
+
   val option : t -> f:(t -> 'a -> unit) -> 'a option -> unit
   val list : t -> f:(t -> 'a -> unit) -> 'a list -> unit
   val repr : t -> 'a Repr.t -> 'a -> unit

--- a/src/dune_engine/action_builder.ml
+++ b/src/dune_engine/action_builder.ml
@@ -285,19 +285,19 @@ and exec_memo_eval : type i o m. (i, o) memo -> i -> m eval_mode -> (o * m) Memo
   | Eager -> Memo.exec (Lazy.force memo.eager) i
 ;;
 
-let memoize ?cutoff name t =
+let memoize ?cutoff _name t =
   let lazy_ =
     lazy
       (let cutoff =
          Option.map cutoff ~f:(fun equal x y -> Tuple.T2.equal equal Dep.Set.equal x y)
        in
-       Memo.lazy_ ?cutoff ~name:(name ^ "(lazy)") (fun () -> eval t Lazy))
+       Memo.lazy_ ?cutoff ~name:"action-builder-lazy" (fun () -> eval t Lazy))
   in
   let eager =
     let cutoff =
       Option.map cutoff ~f:(fun equal x y -> Tuple.T2.equal equal Dep.Facts.equal x y)
     in
-    Memo.lazy_ ?cutoff ~name (fun () -> eval t Eager)
+    Memo.lazy_ ?cutoff ~name:"action-builder-eager" (fun () -> eval t Eager)
   in
   Memoize { lazy_; eager }
 ;;

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -208,10 +208,17 @@ module Internal = struct
   ;;
 
   let digest_target_paths d (rule : Rule.t) =
-    let digest_target_path name =
-      Path.Build.relative_fname rule.targets.root name
-      |> Path.Build.to_string
-      |> Digest.Manual.string d
+    let root = Path.Build.to_string rule.targets.root in
+    let digest_target_path =
+      if Path.Build.equal rule.targets.root Path.Build.root
+      then fun name -> Digest.Manual.string d (Filename.to_string name)
+      else
+        fun name ->
+          Digest.Manual.string_with_separator
+            d
+            root
+            ~separator:"/"
+            (Filename.to_string name)
     in
     Digest.Manual.int
       d

--- a/src/dune_engine/dep.ml
+++ b/src/dune_engine/dep.ml
@@ -235,34 +235,27 @@ module Fact = struct
   ;;
 
   module Stable_for_digest = struct
-    type t =
-      | Env of string * string option
-      | File of
-          { path_digest : Digest.t
-          ; file_digest : Digest.t
-          }
-      | File_selector of
-          { file_selector_digest : Digest.t
-          ; facts_digest : Digest.t
-          }
-      | Alias of Digest.t
+    let[@inline always] env d var value =
+      Digest.Manual.int d 0;
+      Digest.Manual.string d var;
+      Digest.Manual.option d ~f:Digest.Manual.string value
+    ;;
 
-    let digest d = function
-      | Env (var, value) ->
-        Digest.Manual.int d 0;
-        Digest.Manual.string d var;
-        Digest.Manual.option d ~f:Digest.Manual.string value
-      | File { path_digest; file_digest } ->
-        Digest.Manual.int d 1;
-        Digest.Manual.digest d path_digest;
-        Digest.Manual.digest d file_digest
-      | File_selector { file_selector_digest; facts_digest } ->
-        Digest.Manual.int d 2;
-        Digest.Manual.digest d file_selector_digest;
-        Digest.Manual.digest d facts_digest
-      | Alias digest ->
-        Digest.Manual.int d 3;
-        Digest.Manual.digest d digest
+    let[@inline always] file d path_digest file_digest =
+      Digest.Manual.int d 1;
+      Digest.Manual.digest d path_digest;
+      Digest.Manual.digest d file_digest
+    ;;
+
+    let[@inline always] file_selector d file_selector_digest facts_digest =
+      Digest.Manual.int d 2;
+      Digest.Manual.digest d file_selector_digest;
+      Digest.Manual.digest d facts_digest
+    ;;
+
+    let[@inline always] alias d digest =
+      Digest.Manual.int d 3;
+      Digest.Manual.digest d digest
     ;;
   end
 
@@ -406,24 +399,15 @@ module Facts = struct
     Map.iteri t ~f:(fun dep fact ->
       match dep with
       | Env var ->
-        Fact.Stable_for_digest.digest
-          digest
-          (Fact.Stable_for_digest.Env (Env.Var.to_string var, Env.get env var))
+        Fact.Stable_for_digest.env digest (Env.Var.to_string var) (Env.get env var)
       | Universe -> ()
       | File _ | File_selector _ | Alias _ ->
         (match (fact : Fact.t) with
          | Nothing -> ()
          | File (p, d) ->
-           Fact.Stable_for_digest.digest
-             digest
-             (Fact.Stable_for_digest.File
-                { path_digest = Digest.string (Path.to_string p); file_digest = d })
+           Fact.Stable_for_digest.file digest (Digest.string (Path.to_string p)) d
          | File_selector { file_selector_digest; facts } ->
-           Fact.Stable_for_digest.digest
-             digest
-             (Fact.Stable_for_digest.File_selector
-                { file_selector_digest; facts_digest = facts.digest })
-         | Alias ps ->
-           Fact.Stable_for_digest.digest digest (Fact.Stable_for_digest.Alias ps.digest)))
+           Fact.Stable_for_digest.file_selector digest file_selector_digest facts.digest
+         | Alias ps -> Fact.Stable_for_digest.alias digest ps.digest))
   ;;
 end

--- a/src/dune_engine/load_rules.ml
+++ b/src/dune_engine/load_rules.ml
@@ -494,7 +494,7 @@ end = struct
           Build_only_sub_dirs.union r.build_dir_only_sub_dirs build_dir_only_sub_dirs
       ; directory_targets = Path.Build.Map.union_exn r.directory_targets directory_targets
       ; rules =
-          Memo.lazy_ (fun () ->
+          Memo.lazy_ ~name:"union-rules" (fun () ->
             let open Memo.O in
             let+ r = Memo.Lazy.force r.rules
             and+ r' = Memo.Lazy.force rules in
@@ -561,7 +561,7 @@ end = struct
       check_all_directory_targets_are_descendant ~of_ directory_targets;
       check_all_sub_dirs_rule_dirs_are_descendant ~of_ build_dir_only_sub_dirs;
       let rules =
-        Memo.lazy_ (fun () ->
+        Memo.lazy_ ~name:"check-rules-are-descendant" (fun () ->
           let+ rules = rules in
           check_all_rules_are_descendant ~of_ rules;
           rules)

--- a/src/dune_pkg/opam_solver.ml
+++ b/src/dune_pkg/opam_solver.ml
@@ -948,7 +948,19 @@ module Solver = struct
         in
         find_undecided root_req
       in
-      match Sat.run_solver sat decider with
+      let start = Time.now () in
+      let result = Sat.run_solver sat decider in
+      let stop = Time.now () in
+      Dune_trace.emit Sat (fun () ->
+        let stats = Sat.get_stats sat in
+        Dune_trace.Event.sat_solve
+          ~start
+          ~dur:(Time.diff stop start)
+          ~num_variables:stats.num_variables
+          ~num_clauses:stats.num_clauses
+          ~num_decisions:stats.num_decisions
+          ~num_conflicts:stats.num_conflicts);
+      match result with
       | false -> None
       | true ->
         (* Build the results object *)

--- a/src/dune_rules/artifacts.ml
+++ b/src/dune_rules/artifacts.ml
@@ -156,7 +156,7 @@ let create =
   fun (context : Context.t)
     ~(local_bins : origin Appendable_list.t Filename.Map.t Memo.Lazy.t) ->
   let local_bins =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"artifact-local-binaries" (fun () ->
       let+ local_bins = Memo.Lazy.force local_bins in
       Filename.Map.to_list_map local_bins ~f:(fun name sources ->
         ( Filename.of_string_exn (Bin.strip_exe (Filename.to_string name))

--- a/src/dune_rules/command.ml
+++ b/src/dune_rules/command.ml
@@ -113,6 +113,12 @@ and expand_list
            ; targets
            })
       | S nested :: ts -> expand_all nested (ts :: stack) builds targets
+      | A string :: ts ->
+        let build = Action_builder.return (Appendable_list.singleton string) in
+        expand_all ts stack (build :: builds) targets
+      | As strings :: ts ->
+        let build = Action_builder.return (Appendable_list.of_list strings) in
+        expand_all ts stack (build :: builds) targets
       | t :: ts ->
         let { Action_builder.With_targets.build; targets = new_targets } =
           expand ~dir t

--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -349,7 +349,7 @@ let for_module_generated_at_link_time cctx ~requires ~module_ =
   { cctx with
     opaque
   ; flags = Ocaml_flags.empty
-  ; requires_link = Memo.lazy_ (fun () -> requires)
+  ; requires_link = Memo.lazy_ ~name:"requires-link" (fun () -> requires)
   ; requires_compile = requires
   ; user_written_requires = None
   ; includes
@@ -366,7 +366,7 @@ let for_wrapped_compat t =
 let for_plugin_executable t ~embed_in_plugin_libraries =
   let libs = Scope.libs t.scope in
   let requires_link =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"plugin-requires-link" (fun () ->
       Resolve.Memo.List.map ~f:(Lib.DB.resolve libs) embed_in_plugin_libraries)
   in
   { t with requires_link }

--- a/src/dune_rules/context.ml
+++ b/src/dune_rules/context.ml
@@ -419,6 +419,7 @@ let create (builder : Builder.t) ~(kind : Kind.t) =
     | Lock _ ->
       let env =
         Memo.lazy_
+          ~name:"context-base-env"
           ~human_readable_description:(fun () ->
             Pp.textf
               "base environment for context %S"
@@ -452,6 +453,7 @@ let create (builder : Builder.t) ~(kind : Kind.t) =
   in
   let ocamlpath =
     Memo.lazy_
+      ~name:"context-ocamlpath"
       ~human_readable_description:(fun () ->
         Pp.textf "loading OCAMLPATH for context %S" (Context_name.to_string builder.name))
       (fun () ->
@@ -463,6 +465,7 @@ let create (builder : Builder.t) ~(kind : Kind.t) =
   in
   let findlib =
     Memo.lazy_
+      ~name:"context-findlib"
       ~human_readable_description:(fun () ->
         Pp.textf "loading findlib for context %S" (Context_name.to_string builder.name))
       (fun () ->
@@ -529,6 +532,7 @@ let create (builder : Builder.t) ~(kind : Kind.t) =
   let builder =
     let installed_env =
       Memo.lazy_
+        ~name:"context-installed-env"
         ~human_readable_description:(fun () ->
           Pp.textf
             "creating installed environment for %S"

--- a/src/dune_rules/dep_conf_eval.ml
+++ b/src/dune_rules/dep_conf_eval.ml
@@ -427,7 +427,10 @@ and named_paths_builder ~expander l =
              with
              | Some x ->
                let open Memo.O in
-               let x = Memo.lazy_ (fun () -> Memo.all_concurrently x >>| List.concat) in
+               let x =
+                 Memo.lazy_ ~name:"named-dependency-bindings" (fun () ->
+                   Memo.all_concurrently x >>| List.concat)
+               in
                let bindings =
                  Pform.Map.set
                    bindings

--- a/src/dune_rules/dep_graph.ml
+++ b/src/dune_rules/dep_graph.ml
@@ -71,18 +71,10 @@ module Ml_kind = struct
   let dummy m = Ml_kind.Dict.make_both (dummy m)
 
   let for_module_compilation ~modules ({ impl; intf } : t) =
-    let dedupe_modules modules =
-      let _, modules =
-        List.fold_left
-          modules
-          ~init:(Module_name.Unique.Set.empty, [])
-          ~f:(fun (seen, acc) module_ ->
-            let obj_name = Module.obj_name module_ in
-            if Module_name.Unique.Set.mem seen obj_name
-            then seen, acc
-            else Module_name.Unique.Set.add seen obj_name, module_ :: acc)
-      in
-      List.rev modules
+    let dedupe_modules =
+      String.Table.dedupe_by ~key:(fun module_ ->
+        Module.obj_name module_ |> Module_name.Unique.to_string)
+      |> Staged.unstage
     in
     let merge_impl_and_intf_deps obj_name impl_deps =
       let intf_deps = Module_name.Unique.Map.find_exn intf.per_module obj_name in

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -335,7 +335,7 @@ let make_imported_vlib_deps ~obj_dir ~vimpl ~dir ~sctx ~sandbox ~for_ : imported
       Lib_info.obj_dir info
     in
     let transitive_deps =
-      Memo.lazy_ (fun () ->
+      Memo.lazy_ ~name:"transitive-module-dependencies" (fun () ->
         let+ modules = preprocessed_modules_of_local_lib ~sctx lib ~for_ in
         let modules = Modules.With_vlib.modules modules in
         create_transitive_deps

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -58,7 +58,7 @@ module Standalone_or_root = struct
 
   let empty ~dir ~source_dir =
     { contents =
-        Memo.Lazy.create (fun () ->
+        Memo.Lazy.create ~name:"empty-dir-contents" (fun () ->
           Memo.return
             { root = empty Standalone ~dir ~source_dir
             ; rules = Rules.empty
@@ -233,13 +233,13 @@ end = struct
   ;;
 
   let mlds ~sctx ~dir ~dune_file ~files =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"documentation-sources" (fun () ->
       let* expander = Super_context.expander sctx ~dir in
       Doc_sources.build_mlds_map dune_file ~dir ~files expander)
   ;;
 
   let ml_sources sctx ~dir ~project ~lib_config ~loc ~include_subdirs ~dirs ~for_ =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"ml-sources" (fun () ->
       let lookup_vlib = lookup_vlib sctx ~current_dir:dir ~for_ in
       let libs = Scope.DB.find_by_dir dir >>| Scope.libs in
       let* expander = Super_context.expander sctx ~dir
@@ -265,7 +265,7 @@ end = struct
   let make_standalone sctx st_dir ~dir (d : Dune_file.t) =
     let human_readable_description () = human_readable_description dir in
     { Standalone_or_root.contents =
-        Memo.lazy_ ~human_readable_description (fun () ->
+        Memo.lazy_ ~name:"standalone-dir-contents" ~human_readable_description (fun () ->
           let include_subdirs = Loc.none, Include_subdirs.No in
           let ctx = Super_context.context sctx in
           let lib_config =
@@ -280,7 +280,7 @@ end = struct
               stanzas >>= load_text_files sctx st_dir ~src_dir ~dir)
           in
           let dirs =
-            Memo.lazy_ (fun () ->
+            Memo.lazy_ ~name:"standalone-source-file-dirs" (fun () ->
               let+ stanzas = stanzas in
               Nonempty_list.
                 [ { Source_file_dir.dir
@@ -305,13 +305,13 @@ end = struct
               ; melange
               ; mlds
               ; foreign_sources =
-                  Memo.lazy_ (fun () ->
+                  Memo.lazy_ ~name:"standalone-foreign-sources" (fun () ->
                     let dune_version = Dune_project.dune_version project in
                     let* stanzas = stanzas
                     and* dirs = Memo.Lazy.force dirs in
                     Foreign_sources.make stanzas ~dir ~dune_version ~dirs)
               ; rocq =
-                  Memo.lazy_ (fun () ->
+                  Memo.lazy_ ~name:"standalone-rocq-sources" (fun () ->
                     let+ stanzas = stanzas
                     and+ dirs = Memo.Lazy.force dirs in
                     Rocq_sources.of_dir stanzas ~dir ~include_subdirs ~dirs)
@@ -335,6 +335,7 @@ end = struct
     let+ components = components in
     let contents =
       Memo.lazy_
+        ~name:"group-dir-contents"
         ~human_readable_description:(fun () -> human_readable_description dir)
         (fun () ->
            let ctx = Super_context.context sctx in
@@ -370,7 +371,7 @@ end = struct
                         })))
            in
            let dirs =
-             Memo.lazy_ (fun () ->
+             Memo.lazy_ ~name:"group-source-file-dirs" (fun () ->
                let+ stanzas = stanzas in
                Nonempty_list.(
                  { Source_file_dir.dir
@@ -389,14 +390,14 @@ end = struct
              language_sources sctx ~dir ~project ~lib_config ~loc ~include_subdirs ~dirs
            in
            let foreign_sources =
-             Memo.lazy_ (fun () ->
+             Memo.lazy_ ~name:"group-foreign-sources" (fun () ->
                let dune_version = Dune_project.dune_version project in
                let* stanzas = stanzas
                and* dirs = Memo.Lazy.force dirs in
                Foreign_sources.make stanzas ~dir ~dune_version ~dirs)
            in
            let rocq =
-             Memo.lazy_ (fun () ->
+             Memo.lazy_ ~name:"group-rocq-sources" (fun () ->
                let+ stanzas = stanzas
                and+ dirs = Memo.Lazy.force dirs in
                Rocq_sources.of_dir stanzas ~dir ~dirs ~include_subdirs)

--- a/src/dune_rules/dir_status.ml
+++ b/src/dune_rules/dir_status.ml
@@ -267,7 +267,9 @@ end = struct
     >>| get_include_subdirs
     >>= function
     | Some (loc, Include mode) ->
-      let components = Memo.Lazy.create (fun () -> collect_group st_dir ~dir) in
+      let components =
+        Memo.Lazy.create ~name:"group-components" (fun () -> collect_group st_dir ~dir)
+      in
       Memo.return
       @@ T.Group_root
            { source_dir = st_dir

--- a/src/dune_rules/dune_file.ml
+++ b/src/dune_rules/dune_file.ml
@@ -429,7 +429,7 @@ module Eval = struct
       match dynamic_includes with
       | [] -> Memo.Lazy.of_val t.static_stanzas
       | _ :: _ ->
-        Memo.lazy_
+        Memo.lazy_ ~name:"dynamic-includes"
         @@ fun () ->
         let+ stanzas =
           let origin =

--- a/src/dune_rules/dune_load.ml
+++ b/src/dune_rules/dune_load.ml
@@ -11,7 +11,8 @@ module Dune_file_db = struct
 
   let per_context dune_files =
     Per_context.create_by_name ~name:"dune-file-db" (fun ctx ->
-      Memo.lazy_ (fun () -> dune_files ctx >>| make) |> Memo.Lazy.force)
+      Memo.lazy_ ~name:"dune-file-db" (fun () -> dune_files ctx >>| make)
+      |> Memo.Lazy.force)
   ;;
 end
 
@@ -154,7 +155,7 @@ let load () =
         Dune_file.eval dune_files mask)
     in
     Per_context.create_by_name ~name:"dune-files" (fun ctx ->
-      Memo.Lazy.create (fun () ->
+      Memo.Lazy.create ~name:"dune-files-for-context" (fun () ->
         let* f = Memo.Lazy.force without_ctx in
         f ctx)
       |> Memo.Lazy.force)

--- a/src/dune_rules/env_node.ml
+++ b/src/dune_rules/env_node.ml
@@ -31,7 +31,7 @@ let make
   let open Memo.O in
   let config = Dune_env.find config_stanza ~profile in
   let inherited ~field ~root extend =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"inherited-environment-field" (fun () ->
       (match inherit_from with
        | None -> root
        | Some t -> Memo.Lazy.force t >>= field)
@@ -58,7 +58,8 @@ let make
       >>| Artifacts.add_binaries binaries ~dir)
   in
   let local_binaries =
-    Memo.lazy_ (fun () -> Memo.Lazy.force artifacts >>= Artifacts.local_binaries)
+    Memo.lazy_ ~name:"local-binaries" (fun () ->
+      Memo.Lazy.force artifacts >>= Artifacts.local_binaries)
   in
   { external_env; artifacts; local_binaries }
 ;;

--- a/src/dune_rules/env_stanza_db.ml
+++ b/src/dune_rules/env_stanza_db.ml
@@ -132,7 +132,7 @@ module Inherit = struct
         ~(f : parent:a Memo.t -> dir:Path.Build.t -> Dune_env.config -> a Memo.t)
     =
     let for_context =
-      Memo.Lazy.create (fun () ->
+      Memo.Lazy.create ~name:"environment-stanzas-for-context" (fun () ->
         let+ context = Context.DB.get context in
         let profile = Context.profile context in
         let { Context.Env_nodes.context; workspace } = Context.env_nodes context in

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -94,7 +94,7 @@ let extend_env t ~env =
   (* [t.local_env] has precedence over [t.env], so we cannot extend [env] if
      there are already local bindings.. *)
   let env =
-    Memo.Lazy.create (fun () ->
+    Memo.Lazy.create ~name:"extended-environment" (fun () ->
       let open Memo.O in
       let+ env = env
       and+ base = t.env in

--- a/src/dune_rules/fetch_rules.ml
+++ b/src/dune_rules/fetch_rules.ml
@@ -164,7 +164,7 @@ let find_checksum, find_url =
     Checksum.Map.superpose checksums checksums', Digest.Map.superpose urls urls'
   in
   let all =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"all-fetches" (fun () ->
       let* init =
         Memo.List.fold_left
           Dune_pkg.Dev_tool.all

--- a/src/dune_rules/findlib.ml
+++ b/src/dune_rules/findlib.ml
@@ -593,7 +593,7 @@ type t = DB.t
 
 let create_with_paths ~paths =
   Per_context.create_by_name ~name:"findlib" (fun context ->
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"findlib" (fun () ->
       let* context = Context.DB.get context in
       let* lib_config =
         let+ ocaml = Context.ocaml context in

--- a/src/dune_rules/gen_rules.ml
+++ b/src/dune_rules/gen_rules.ml
@@ -750,7 +750,7 @@ let private_context ~dir components _ctx =
 
 let raise_on_lock_dir_out_of_sync =
   Per_context.create_by_name ~name:"check-lock-dir" (fun ctx ->
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"check-lock-dir" (fun () ->
       let* lock_dir_available = Lock_dir.lock_dir_active ctx in
       if lock_dir_available
       then

--- a/src/dune_rules/inline_tests.ml
+++ b/src/dune_rules/inline_tests.ml
@@ -311,7 +311,8 @@ include Sub_system.Register_end_point (struct
           ~opaque:(Explicit false)
           ~requires_compile:runner_libs
           ~user_written_requires:None
-          ~requires_link:(Memo.lazy_ (fun () -> runner_libs))
+          ~requires_link:
+            (Memo.lazy_ ~name:"inline-test-requires-link" (fun () -> runner_libs))
           ~flags
           ~js_of_ocaml:(Js_of_ocaml.Mode.Pair.map ~f:Option.some js_of_ocaml)
           ~melange_package_name:None

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -1204,7 +1204,7 @@ module Resolve_names : sig
          Staged.t
 end = struct
   let projects_by_package =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"projects-by-package" (fun () ->
       let open Memo.O in
       Dune_load.projects ()
       >>| List.concat_map ~f:(fun project ->
@@ -1518,7 +1518,7 @@ end = struct
     let default_implementation =
       Lib_info.default_implementation info
       |> Option.map ~f:(fun l ->
-        Memo.lazy_ (fun () ->
+        Memo.lazy_ ~name:"default-library-implementation" (fun () ->
           let open Resolve.Memo.O in
           let* impl = resolve_impl l in
           match Lib_info.package impl.info with
@@ -1655,7 +1655,7 @@ end = struct
          ; project
          ; sub_systems =
              Sub_system_name.Map.mapi (Lib_info.sub_systems info) ~f:(fun name info ->
-               Memo.Lazy.create (fun () ->
+               Memo.Lazy.create ~name:"library-sub-system" (fun () ->
                  Sub_system.instantiate
                    name
                    info
@@ -2280,7 +2280,7 @@ module Compile = struct
     let requires_link : lib list Resolve.t Memo.Lazy.t Compilation_mode.Per_mode.t =
       let db = Option.some_if (not allow_overlaps) db in
       Compilation_mode.Per_mode.map requires ~f:(fun ~for_ requires ->
-        Memo.lazy_ (fun () ->
+        Memo.lazy_ ~name:"library-requires-link" (fun () ->
           let open Resolve.Memo.O in
           requires
           >>= Resolve_names.compile_closure_with_overlap_checks
@@ -2367,7 +2367,7 @@ module DB = struct
         { parent
         ; resolve
         ; resolve_lib_id
-        ; all = Memo.lazy_ all
+        ; all = Memo.lazy_ ~name:"library-db-all" all
         ; instrument_with
         ; instantiate
         }
@@ -2511,7 +2511,7 @@ module DB = struct
       | `Exe _ -> Ocaml
     in
     let resolved =
-      Memo.lazy_ (fun () ->
+      Memo.lazy_ ~name:"resolved-library-dependencies" (fun () ->
         Resolve_names.resolve_deps_and_add_runtime_deps
           t
           deps
@@ -2523,7 +2523,7 @@ module DB = struct
     in
     let requires_link : lib list Resolve.t Memo.Lazy.t Compilation_mode.Per_mode.t =
       let requires_link =
-        Memo.Lazy.create (fun () ->
+        Memo.Lazy.create ~name:"library-requires-link" (fun () ->
           let* forbidden_libraries =
             Resolve.Memo.List.map forbidden_libraries ~f:(fun (loc, name) ->
               let+ lib = resolve t (loc, name) in
@@ -2562,7 +2562,9 @@ module DB = struct
                      (Nonempty_list.map ~f:snd names |> Nonempty_list.to_list))
                   (Loc.to_file_colon_line loc)))
       in
-      let init = Memo.lazy_ (fun () -> Resolve.Memo.return []) in
+      let init =
+        Memo.lazy_ ~name:"empty-library-requires-link" (fun () -> Resolve.Memo.return [])
+      in
       Compilation_mode.Per_mode.of_list ~init [ for_, requires_link ]
     in
     let pps : lib list Resolve.Memo.t Compilation_mode.Per_mode.t =
@@ -2601,7 +2603,7 @@ module DB = struct
       : (Loc.t * lib) list Resolve.Memo.t Compilation_mode.Per_mode.t
       =
       let resolved_user_written_requires =
-        Memo.lazy_ (fun () ->
+        Memo.lazy_ ~name:"user-written-library-requires" (fun () ->
           Resolve_names.resolve_complex_deps
             t
             ~private_deps:Allow_all

--- a/src/dune_rules/lib.ml
+++ b/src/dune_rules/lib.ml
@@ -398,9 +398,12 @@ module T = struct
     }
 
   let rec compare (x : t) (y : t) =
-    match Id.compare x.unique_id y.unique_id with
-    | (Lt | Gt) as cmp -> cmp
-    | Eq -> compare_arguments x y
+    if Stdlib.( == ) x y
+    then Eq
+    else (
+      match Id.compare x.unique_id y.unique_id with
+      | (Lt | Gt) as cmp -> cmp
+      | Eq -> compare_arguments x y)
 
   and compare_arguments a b =
     List.compare a.arguments b.arguments ~compare:(Option.compare compare)

--- a/src/dune_rules/lib_flags.ml
+++ b/src/dune_rules/lib_flags.ml
@@ -164,17 +164,15 @@ module L = struct
         else acc
       | true ->
         let public_cmi_dirs =
-          List.map
-            ~f:(fun f -> f obj_dir)
-            (match mode with
-             | { lib_mode = Ocaml _; _ } -> [ Obj_dir.public_cmi_ocaml_dir ]
-             | { lib_mode = Melange; melange_emit = false } ->
-               [ Obj_dir.public_cmi_melange_dir ]
-             | { lib_mode = Melange; melange_emit = true } ->
-               (* Add the dir where [.cmj] files exist, even for installed
-                  private libraries. Melange needs to query [.cmj] files for
-                  [import] information *)
-               [ Obj_dir.melange_dir; Obj_dir.public_cmi_melange_dir ])
+          match mode with
+          | { lib_mode = Ocaml _; _ } -> [ Obj_dir.public_cmi_ocaml_dir obj_dir ]
+          | { lib_mode = Melange; melange_emit = false } ->
+            [ Obj_dir.public_cmi_melange_dir obj_dir ]
+          | { lib_mode = Melange; melange_emit = true } ->
+            (* Add the dir where [.cmj] files exist, even for installed
+               private libraries. Melange needs to query [.cmj] files for
+               [import] information *)
+            Obj_dir.all_obj_dirs obj_dir ~mode:Melange
         in
         let acc =
           List.fold_left public_cmi_dirs ~init:acc ~f:(fun acc dir ->

--- a/src/dune_rules/lock_dir.ml
+++ b/src/dune_rules/lock_dir.ml
@@ -225,7 +225,7 @@ let get_with_path =
             Load.load path))
   in
   Per_context.create_by_name ~name:"lock-dir-get" (fun ctx ->
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"lock-dir-get" (fun () ->
       let* path =
         get_path ctx
         >>| function

--- a/src/dune_rules/main.ml
+++ b/src/dune_rules/main.ml
@@ -89,7 +89,7 @@ let init ~sandbox_actions ~sandboxing_preference () : unit =
     ~sandboxing_preference
     ~promote_source
     ~contexts:
-      (Memo.lazy_ (fun () ->
+      (Memo.lazy_ ~name:"build-context-types" (fun () ->
          let open Memo.O in
          let+ contexts = Workspace.workspace () >>| Workspace.build_contexts in
          let open Dune_engine.Build_config.Context_type in

--- a/src/dune_rules/menhir/menhir_rules.ml
+++ b/src/dune_rules/menhir/menhir_rules.ml
@@ -187,7 +187,7 @@ module Run (P : PARAMS) = struct
      like to change it in the future. *)
 
   let stanzas : (stanza * Path.Set.t) list Memo.Lazy.t =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"menhir-stanzas" (fun () ->
       let open Memo.O in
       let+ { Ml_sources.Parser_generators.deps; targets = _ } =
         let sctx = Compilation_context.super_context cctx in
@@ -211,7 +211,7 @@ module Run (P : PARAMS) = struct
      using these commands appropriately. Fail if they are present. *)
 
   let check =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"check-menhir-flags" (fun () ->
       let open Memo.O in
       Memo.Lazy.force stanzas
       >>| List.iter ~f:(fun ((stanza, _) : stanza * Path.Set.t) ->

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -1368,7 +1368,7 @@ let make
   in
   let modules = Per_stanza.make modules_of_stanzas in
   let artifacts =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"module-artifacts" (fun () ->
       let libs =
         List.map modules_of_stanzas.libraries ~f:(fun (part : _ Per_stanza.group_part) ->
           part.stanza, part.modules, part.obj_dir)

--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -153,7 +153,15 @@ module External = struct
   let dir t = t.public_dir.ocaml
   let obj_dir t = t.public_dir.ocaml
   let odoc_dir t = t.public_dir.ocaml
-  let all_obj_dirs t ~mode:_ = [ t.public_dir.ocaml ]
+
+  let all_obj_dirs t ~(mode : Lib_mode.t) =
+    match mode with
+    | Ocaml _ -> [ t.public_dir.ocaml ]
+    | Melange ->
+      [ t.public_dir.melange; public_cmi_melange_dir t ]
+      |> Path.Set.of_list
+      |> Path.Set.to_list
+  ;;
 
   let all_cmis { public_dir; private_dir; public_cmi_dir } =
     List.filter_opt

--- a/src/dune_rules/ocaml_toolchain.ml
+++ b/src/dune_rules/ocaml_toolchain.ml
@@ -17,7 +17,7 @@ type t =
   }
 
 let make_builtins ~ocaml_config ~version =
-  Memo.Lazy.create (fun () ->
+  Memo.Lazy.create ~name:"ocaml-toolchain-builtins" (fun () ->
     let stdlib_dir = Path.of_string (Ocaml_config.standard_library ocaml_config) in
     Meta.builtins ~stdlib_dir ~version)
 ;;

--- a/src/dune_rules/per_context.ml
+++ b/src/dune_rules/per_context.ml
@@ -28,10 +28,10 @@ let all =
 
 let list () = Memo.Lazy.force all >>| Context_name.Map.keys
 
-let create_db ?cutoff ~name f =
+let create_db ?cutoff ~name:_name f =
   let cutoff = Option.map cutoff ~f:(fun equal -> Context_name.Map.equal ~equal) in
   let map =
-    Memo.lazy_ ~name ?cutoff (fun () ->
+    Memo.lazy_ ~name:"per-context-map" ?cutoff (fun () ->
       let+ map = Memo.Lazy.force all in
       Context_name.Map.mapi map ~f)
   in

--- a/src/dune_rules/pkg_rules.ml
+++ b/src/dune_rules/pkg_rules.ml
@@ -1180,6 +1180,7 @@ module Action_expander = struct
   let expander context (pkg : Pkg.t) =
     let closure =
       Memo.lazy_
+        ~name:"package-dependency-closure"
         ~human_readable_description:(fun () ->
           Pp.textf
             "Computing closure for package %S"
@@ -1188,11 +1189,14 @@ module Action_expander = struct
     in
     let env = Pkg.exported_value_env pkg in
     let depends =
-      Memo.Lazy.map closure ~f:(fun { Artifacts_and_deps.dep_info; _ } ->
-        Package.Name.Map.add_exn
-          dep_info
-          pkg.info.name
-          (Pkg_info.variables pkg.info, pkg.paths))
+      Memo.Lazy.map
+        ~name:"package-dependency-info"
+        closure
+        ~f:(fun { Artifacts_and_deps.dep_info; _ } ->
+          Package.Name.Map.add_exn
+            dep_info
+            pkg.info.name
+            (Pkg_info.variables pkg.info, pkg.paths))
       |> Memo.Lazy.force
     in
     let artifacts =
@@ -1389,7 +1393,7 @@ module DB = struct
     ;;
 
     let all_existing_dev_tools =
-      Memo.lazy_ (fun () ->
+      Memo.lazy_ ~name:"all-existing-dev-tools" (fun () ->
         let* platform = Lock_dir.Sys_vars.solver_env in
         let+ xs =
           Memo.List.map
@@ -1477,7 +1481,7 @@ module DB = struct
   let of_dev_tool =
     let system_provided = default_system_provided in
     let inactive_lockdir =
-      Memo.lazy_ (fun () ->
+      Memo.lazy_ ~name:"inactive-lockdir-package-db" (fun () ->
         let+ pkg_digest_table = Memo.Lazy.force Pkg_table.all_existing_dev_tools in
         create ~pkg_digest_table ~system_provided)
     in
@@ -2565,6 +2569,7 @@ let all_project_deps context = all_deps (Dependencies context)
 let which context =
   let artifacts_and_deps =
     Memo.lazy_
+      ~name:"lock-directory-binaries"
       ~human_readable_description:(fun () ->
         Pp.textf
           "Loading all binaries in the lock directory for %S"

--- a/src/dune_rules/ppx_driver.ml
+++ b/src/dune_rules/ppx_driver.ml
@@ -216,7 +216,7 @@ let build_ppx_driver =
     and+ cctx =
       let obj_dir = Obj_dir.for_pp ~dir in
       let requires_compile = Resolve.map driver_and_libs ~f:snd in
-      let requires_link = Memo.lazy_ (fun () -> Memo.return requires_compile) in
+      let requires_link = Memo.Lazy.of_val requires_compile in
       let opaque = Compilation_context.Explicit false in
       let modules = Modules.With_vlib.singleton_exe module_ in
       Compilation_context.create

--- a/src/dune_rules/rocq/rocq_scope.ml
+++ b/src/dune_rules/rocq/rocq_scope.ml
@@ -68,7 +68,7 @@ let rocq_stanzas_by_project_dir rocq_stanzas =
 
 let make context ~public_libs ~db_by_project_dir ~projects_by_root rocq_stanzas =
   { scopes =
-      Memo.lazy_ (fun () ->
+      Memo.lazy_ ~name:"rocq-scopes" (fun () ->
         let+ public_theories = public_theories context public_libs rocq_stanzas in
         let rocq_stanzas_by_project_dir = rocq_stanzas_by_project_dir rocq_stanzas in
         rocq_scopes_by_dir

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -108,7 +108,7 @@ module DB = struct
                 let lib_name, redirect =
                   let old_public_name = Lib_name.of_local s.old_name.lib_name in
                   let enabled =
-                    Memo.lazy_ (fun () ->
+                    Memo.lazy_ ~name:"library-redirect-enabled" (fun () ->
                       let* expander = Expander0.get ~dir in
                       Expander0.eval_blang expander s.old_name.enabled >>| Toggle.of_bool)
                     |> Memo.Lazy.force
@@ -247,7 +247,7 @@ module DB = struct
                   Library.to_lib_id ~src_dir conf
                 in
                 let enabled =
-                  Memo.lazy_ (fun () ->
+                  Memo.lazy_ ~name:"library-enabled" (fun () ->
                     let* expander = Expander0.get ~dir in
                     Expander0.eval_blang expander conf.enabled_if >>| Toggle.of_bool)
                   |> Memo.Lazy.force
@@ -397,7 +397,7 @@ module DB = struct
 
   let all =
     Per_context.create_by_name ~name:"scope" (fun context ->
-      Memo.Lazy.create (fun () ->
+      Memo.Lazy.create ~name:"scope" (fun () ->
         let* projects_by_root = Dune_load.projects_by_root ()
         and* stanzas = Dune_load.dune_files context in
         create_from_stanzas ~projects_by_root ~context stanzas)
@@ -546,7 +546,7 @@ module DB = struct
     in
     let per_context =
       Per_context.create_by_name ~name:"scope-db" (fun ctx ->
-        Memo.lazy_ (fun () ->
+        Memo.lazy_ ~name:"scope-db" (fun () ->
           let* public_libs =
             let* ctx = Context.DB.get ctx in
             public_libs (Context.name ctx)

--- a/src/dune_rules/super_context.ml
+++ b/src/dune_rules/super_context.ml
@@ -72,7 +72,7 @@ let get_env_stanza ~dir =
 
 let get_impl t dir =
   let inherit_from =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"inherited-environment-node" (fun () ->
       let* scope_root = Dune_load.find_project ~dir >>| Dune_project.root in
       if Path.Source.equal (Path.Build.drop_build_context_exn dir) scope_root
       then Memo.Lazy.force t.default_env
@@ -86,7 +86,8 @@ let get_impl t dir =
   in
   let+ config_stanza = get_env_stanza ~dir in
   let expander =
-    Memo.lazy_ (fun () -> expander_for_artifacts t ~dir) |> Memo.Lazy.force
+    Memo.lazy_ ~name:"expander-for-artifacts" (fun () -> expander_for_artifacts t ~dir)
+    |> Memo.Lazy.force
   in
   let profile = Context.profile t.context in
   Env_node.make
@@ -244,14 +245,14 @@ let make_default_env_node
     ~config_stanza:env_nodes.context
     ~inherit_from:
       (Some
-         (Memo.lazy_ (fun () ->
+         (Memo.lazy_ ~name:"workspace-environment-node" (fun () ->
             make ~inherit_from:None ~config_stanza:env_nodes.workspace |> Memo.return)))
 ;;
 
 let create ~(context : Context.t) ~(host : t option) ~packages ~stanzas =
   let context_name = Context.name context in
   let env =
-    Memo.lazy_ (fun () ->
+    Memo.lazy_ ~name:"super-context-environment" (fun () ->
       let* base =
         let* base = Context.installed_env context in
         match host with

--- a/src/dune_rules/utop.ml
+++ b/src/dune_rules/utop.ml
@@ -145,7 +145,7 @@ let requires ~loc ~db ~libs =
 ;;
 
 let utop_dev_tool_lock_dir_exists =
-  Memo.Lazy.create (fun () ->
+  Memo.Lazy.create ~name:"utop-dev-tool-lock-dir-exists" (fun () ->
     let path = Lock_dir.dev_tool_external_lock_dir Utop in
     Fs_memo.dir_exists (Path.Outside_build_dir.External path))
 ;;
@@ -157,7 +157,9 @@ let utop_findlib_conf =
 (* The lib directory of the utop package and of each of its dependencies within
    the _build directory (or the toolchains directory in the case of the OCaml
    compiler). *)
-let utop_ocamlpath = Memo.Lazy.create (fun () -> Pkg_rules.dev_tool_ocamlpath Utop)
+let utop_ocamlpath =
+  Memo.Lazy.create ~name:"utop-ocamlpath" (fun () -> Pkg_rules.dev_tool_ocamlpath Utop)
+;;
 
 (* Creates a rule that generates a custom findlib.conf containing the path to
    the utop library as well as all of its dependencies in the _build directory
@@ -231,7 +233,7 @@ let setup sctx ~dir =
     Ocaml_flags.append_common (Ocaml_flags.default ~dune_version ~profile) [ "-w"; "-24" ]
   in
   let* cctx =
-    let requires_link = Memo.lazy_ (fun () -> requires) in
+    let requires_link = Memo.lazy_ ~name:"utop-requires-link" (fun () -> requires) in
     Compilation_context.create
       for_
       ~super_context:sctx

--- a/src/dune_targets/dune_targets.ml
+++ b/src/dune_targets/dune_targets.ml
@@ -134,35 +134,42 @@ module Validation_result = struct
 end
 
 let validate { files; dirs } =
-  let add_file (t : Validated.t) name =
-    Validation_result.Valid { t with files = Filename.Set.add t.files name }
-  in
-  let add_dir (t : Validated.t) name =
-    if Filename.Set.mem t.files name
-    then
-      Validation_result.File_and_directory_target_with_the_same_name
-        (Path.Build.relative_fname t.root name)
-    else Valid { t with dirs = Filename.Set.add t.dirs name }
-  in
-  let build (init : Validation_result.t) ~paths ~f =
-    Path.Build.Array.Set.fold paths ~init ~f:(fun path res ->
+  let files_result =
+    Path.Build.Array.Set.fold files ~init:Validation_result.No_targets ~f:(fun path res ->
       let parent = Path.Build.parent_exn path in
       let name = Path.Build.basename path in
       match res with
       | No_targets ->
-        let t =
+        Valid
           { Validated.root = parent
-          ; files = Filename.Set.empty
+          ; files = Filename.Set.singleton name
           ; dirs = Filename.Set.empty
           }
-        in
-        f t name
-      | Valid t when Path.Build.equal t.root parent -> f t name
+      | Valid t when Path.Build.equal t.root parent ->
+        Valid { t with files = Filename.Set.add t.files name }
       | Valid _ -> Inconsistent_parent_dir
       | (Inconsistent_parent_dir | File_and_directory_target_with_the_same_name _) as res
         -> res)
   in
-  build No_targets ~paths:files ~f:add_file |> build ~paths:dirs ~f:add_dir
+  Path.Build.Array.Set.fold dirs ~init:files_result ~f:(fun path res ->
+    let parent = Path.Build.parent_exn path in
+    let name = Path.Build.basename path in
+    match res with
+    | No_targets ->
+      Valid
+        { Validated.root = parent
+        ; files = Filename.Set.empty
+        ; dirs = Filename.Set.singleton name
+        }
+    | Valid t when Path.Build.equal t.root parent ->
+      if Filename.Set.mem t.files name
+      then
+        File_and_directory_target_with_the_same_name
+          (Path.Build.relative_fname t.root name)
+      else Valid { t with dirs = Filename.Set.add t.dirs name }
+    | Valid _ -> Inconsistent_parent_dir
+    | (Inconsistent_parent_dir | File_and_directory_target_with_the_same_name _) as res ->
+      res)
 ;;
 
 module Produced = struct

--- a/src/dune_trace/category.ml
+++ b/src/dune_trace/category.ml
@@ -25,6 +25,7 @@ type t =
   | Artifact_substitution
   | Thread
   | Runtime
+  | Sat
 
 let all =
   [ Rpc
@@ -51,6 +52,7 @@ let all =
   ; Artifact_substitution
   ; Thread
   ; Runtime
+  ; Sat
   ]
 ;;
 
@@ -79,6 +81,7 @@ let to_string = function
   | Artifact_substitution -> "artifact_subtitution"
   | Thread -> "thread"
   | Runtime -> "runtime"
+  | Sat -> "sat"
 ;;
 
 let of_string =
@@ -119,6 +122,7 @@ module Set = Bit_set.Make (struct
       | Artifact_substitution -> 21
       | Thread -> 22
       | Runtime -> 23
+      | Sat -> 24
     ;;
   end)
 

--- a/src/dune_trace/category.mli
+++ b/src/dune_trace/category.mli
@@ -23,6 +23,7 @@ type t =
   | Artifact_substitution
   | Thread
   | Runtime
+  | Sat
 
 val to_string : t -> string
 val of_string : string -> t option

--- a/src/dune_trace/dune_trace.mli
+++ b/src/dune_trace/dune_trace.mli
@@ -26,6 +26,7 @@ module Category : sig
     | Artifact_substitution
     | Thread
     | Runtime
+    | Sat
 end
 
 module Event : sig
@@ -168,6 +169,15 @@ module Event : sig
   val gc : unit -> t
   val fd_count : unit -> t option
   val spawn_thread : name:string -> t
+
+  val sat_solve
+    :  start:Time.t
+    -> dur:Time.Span.t
+    -> num_variables:int
+    -> num_clauses:int
+    -> num_decisions:int
+    -> num_conflicts:int
+    -> t
 
   module Promote : sig
     val promote : Path.Build.t -> Path.Source.t -> t

--- a/src/dune_trace/event.ml
+++ b/src/dune_trace/event.ml
@@ -1079,6 +1079,17 @@ let spawn_thread ~name =
   Event.instant ~args ~name:"spawn_thread" now Thread
 ;;
 
+let sat_solve ~start ~dur ~num_variables ~num_clauses ~num_decisions ~num_conflicts =
+  let args =
+    [ "num_variables", Arg.int num_variables
+    ; "num_clauses", Arg.int num_clauses
+    ; "num_decisions", Arg.int num_decisions
+    ; "num_conflicts", Arg.int num_conflicts
+    ]
+  in
+  Event.complete ~args ~name:"solve" ~start ~dur Sat
+;;
+
 let sandbox name ~start ~stop ~queued loc ~dir =
   let args =
     [ "loc", Arg.string (Loc.to_file_colon_line loc); "dir", Arg.build_path dir ]

--- a/src/memo/memo.ml
+++ b/src/memo/memo.ml
@@ -288,16 +288,22 @@ let node = dep_node
 
 module Implicit_output = Implicit_output
 
-let lazy_node ?cutoff ?name ?human_readable_description ?on_event f =
+let lazy_node ~name ?cutoff ?human_readable_description ?on_event f =
   let on_event = Option.map on_event ~f:(fun on_event () event -> on_event event) in
   let spec =
-    Spec.create ~name ~input:(module Unit) ~cutoff ~human_readable_description ?on_event f
+    Spec.create
+      ~name:(Some name)
+      ~input:(module Unit)
+      ~cutoff
+      ~human_readable_description
+      ?on_event
+      f
   in
   make_dep_node ~spec ~input:()
 ;;
 
 let push_stack_frame ~human_readable_description f =
-  Node.read (lazy_node ~human_readable_description f)
+  Node.read (lazy_node ~name:"stack-frame" ~human_readable_description f)
 ;;
 
 module Lazy = struct
@@ -306,19 +312,19 @@ module Lazy = struct
   let of_val a () = Fiber.return a
 
   module Expert = struct
-    let create ?cutoff ?name ?human_readable_description ?on_event f =
-      let node = lazy_node ?cutoff ?name ?human_readable_description ?on_event f in
+    let create ~name ?cutoff ?human_readable_description ?on_event f =
+      let node = lazy_node ~name ?cutoff ?human_readable_description ?on_event f in
       node, fun () -> Node.read node
     ;;
   end
 
-  let create ?cutoff ?name ?human_readable_description ?on_event f =
-    let node = lazy_node ?cutoff ?name ?human_readable_description ?on_event f in
+  let create ~name ?cutoff ?human_readable_description ?on_event f =
+    let node = lazy_node ~name ?cutoff ?human_readable_description ?on_event f in
     fun () -> Node.read node
   ;;
 
   let force f = f ()
-  let map t ~f = create (fun () -> Fiber.map ~f (t ()))
+  let map ~name t ~f = create ~name (fun () -> Fiber.map ~f (t ()))
 end
 
 let lazy_ = Lazy.create

--- a/src/memo/memo.mli
+++ b/src/memo/memo.mli
@@ -435,9 +435,11 @@ end
     memoized function. *)
 val node : ('i, 'o) Table.t -> 'i -> ('i, 'o) Node.t
 
+(** Names passed to lazy-node constructors must be string literals so that creating a
+    node does not allocate its name. *)
 val lazy_node
-  :  ?cutoff:('a -> 'a -> bool)
-  -> ?name:string
+  :  name:string
+  -> ?cutoff:('a -> 'a -> bool)
   -> ?human_readable_description:(unit -> User_message.Style.t Pp.t)
   -> ?on_event:(Event.t -> unit)
   -> (unit -> 'a t)
@@ -449,22 +451,22 @@ module Lazy : sig
   val of_val : 'a -> 'a t
 
   val create
-    :  ?cutoff:('a -> 'a -> bool)
-    -> ?name:string
+    :  name:string
+    -> ?cutoff:('a -> 'a -> bool)
     -> ?human_readable_description:(unit -> User_message.Style.t Pp.t)
     -> ?on_event:(Event.t -> unit)
     -> (unit -> 'a memo)
     -> 'a t
 
   val force : 'a t -> 'a memo
-  val map : 'a t -> f:('a -> 'b) -> 'b t
+  val map : name:string -> 'a t -> f:('a -> 'b) -> 'b t
 
   module Expert : sig
     (** Like [Lazy.create] but returns the underlying Memo [Node], which can be
         useful for testing and debugging. *)
     val create
-      :  ?cutoff:('a -> 'a -> bool)
-      -> ?name:string
+      :  name:string
+      -> ?cutoff:('a -> 'a -> bool)
       -> ?human_readable_description:(unit -> User_message.Style.t Pp.t)
       -> ?on_event:(Event.t -> unit)
       -> (unit -> 'a memo)
@@ -473,8 +475,8 @@ module Lazy : sig
 end
 
 val lazy_
-  :  ?cutoff:('a -> 'a -> bool)
-  -> ?name:string
+  :  name:string
+  -> ?cutoff:('a -> 'a -> bool)
   -> ?human_readable_description:(unit -> User_message.Style.t Pp.t)
   -> ?on_event:(Event.t -> unit)
   -> (unit -> 'a t)

--- a/src/sat/sat.ml
+++ b/src/sat/sat.ml
@@ -147,6 +147,15 @@ module Make (User : USER) = struct
     ; mutable set_to_false : bool
     ; conflict_vars : VarID.Hash_set.t
       (* we are finishing up by setting everything else to False *)
+      (* Counters for observability. [num_clauses] counts input clauses
+         added via [at_least_one] / [implies] / [impossible]; the
+         at-most clauses are not counted because they do not carry a
+         problem handle at their construction site (see sat.mli).
+         [num_decisions] and [num_conflicts] are incremented in
+         [run_solver]. *)
+    ; num_clauses : Counter.t
+    ; num_decisions : Counter.t
+    ; num_conflicts : Counter.t
     }
 
   let lit_equal (s1, v1) (s2, v2) = s1 == s2 && v1 == v2
@@ -223,6 +232,9 @@ module Make (User : USER) = struct
     ; toplevel_conflict = false
     ; set_to_false = false
     ; conflict_vars = VarID.Hash_set.create ()
+    ; num_clauses = Counter.create ()
+    ; num_decisions = Counter.create ()
+    ; num_conflicts = Counter.create ()
     }
   ;;
 
@@ -356,7 +368,10 @@ module Make (User : USER) = struct
     done
   ;;
 
-  let impossible problem = problem.toplevel_conflict <- true
+  let impossible problem =
+    Counter.incr problem.num_clauses;
+    problem.toplevel_conflict <- true
+  ;;
 
   (* Call [Clause.propagate lit] when lit becomes True *)
   let watch_lit lit clause =
@@ -626,6 +641,7 @@ module Make (User : USER) = struct
 
   (** Public interface. Only used before the solve starts. *)
   let at_least_one problem ?(reason = "input fact") lits =
+    Counter.incr problem.num_clauses;
     if List.is_empty lits
     then problem.toplevel_conflict <- true
     else if
@@ -910,9 +926,11 @@ module Make (User : USER) = struct
                 ];
             problem.trail_lim <- problem.trail_len :: problem.trail_lim;
             problem.trail_lim_len <- problem.trail_lim_len + 1;
+            Counter.incr problem.num_decisions;
             let r = enqueue problem lit (External "considering") in
             assert r
           | Some conflicting_clause ->
+            Counter.incr problem.num_conflicts;
             if get_decision_level problem = 0
             then (
               if debug then log_debug (Pp.text "FAIL: conflict found at top level");
@@ -960,5 +978,20 @@ module Make (User : USER) = struct
     if value = Undecided
     then Pp.text "undecided!"
     else Pp.hovbox (pp_lit_reason lit ++ Pp.text " => " ++ pp_lit_assignment lit)
+  ;;
+
+  type stats =
+    { num_variables : int
+    ; num_clauses : int
+    ; num_decisions : int
+    ; num_conflicts : int
+    }
+
+  let get_stats problem =
+    { num_variables = List.length problem.vars
+    ; num_clauses = Counter.read problem.num_clauses
+    ; num_decisions = Counter.read problem.num_decisions
+    ; num_conflicts = Counter.read problem.num_conflicts
+    }
   ;;
 end

--- a/src/sat/sat.mli
+++ b/src/sat/sat.mli
@@ -80,4 +80,23 @@ module Make (User : USER) : sig
 
   val get_user_data_for_lit : lit -> User.t
   val explain_reason : lit -> 'tag Pp.t
+
+  (** {2 Observability} *)
+
+  (** Statistics describing a SAT problem and the work done to solve it.
+      [num_variables] and [num_clauses] are structural (the problem size);
+      [num_decisions] and [num_conflicts] are cumulative counters of work
+      performed by the solver. Note that [num_clauses] counts only
+      "at-least-one" / "implies" / "impossible" clauses; the
+      "at-most-{one,n}" clauses (used for conflict-class / mutual-exclusion
+      groupings) are not counted because they do not carry a problem handle
+      at their construction site. *)
+  type stats =
+    { num_variables : int
+    ; num_clauses : int
+    ; num_decisions : int
+    ; num_conflicts : int
+    }
+
+  val get_stats : t -> stats
 end

--- a/src/source/source_tree.ml
+++ b/src/source/source_tree.ml
@@ -131,7 +131,7 @@ let rec physical
       Some
         { Dir0.sub_dir_status = dir_status
         ; sub_dir_as_t =
-            Memo.lazy_node (fun () ->
+            Memo.lazy_node ~name:"source-tree-sub-dir" (fun () ->
               find_dir_raw
                 ~default_vcs
                 ~path
@@ -164,7 +164,7 @@ and virtual_ ~project ~sub_dirs ~parent_status ~dune_file ~init ~path =
               ( fn
               , { Dir0.sub_dir_status = status
                 ; sub_dir_as_t =
-                    Memo.lazy_node (fun () ->
+                    Memo.lazy_node ~name:"source-tree-virtual-sub-dir" (fun () ->
                       find_dir_raw
                         ~default_vcs:Dir0.Vcs.Ancestor_vcs
                         ~path:(Path.Source.relative_fname path fn)
@@ -264,7 +264,7 @@ and find_dir_raw
 ;;
 
 let root =
-  Memo.lazy_node
+  Memo.lazy_node ~name:"source-tree-root"
   @@ fun () ->
   let path = Path.Source.root in
   let dir_status : Source_dir_status.t = Normal in

--- a/test/blackbox-tests/dune.jq
+++ b/test/blackbox-tests/dune.jq
@@ -34,6 +34,8 @@ def inlineTestProcesses:
     processesBrief
   | select(.prog == "inline-test-runner.bc");
 
+def satSolveEvents: select(.cat == "sat" and .name == "solve");
+
 def targetsMatchingFilter(f):
     processes
   | select(.args | targets | any(f))

--- a/test/blackbox-tests/test-cases/boot/cycle.t
+++ b/test/blackbox-tests/test-cases/boot/cycle.t
@@ -19,7 +19,7 @@ Testing cycle detection in bootstrap.
   $ create_dune a <<EOF
   > open A
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   cycle:
   - a__B.ml

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-ambiguous.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-ambiguous.t
@@ -31,6 +31,6 @@ it picks up the closest one.
   > module M1 = A.Bar.Baz
   > let () = Printf.printf "Hello from %s\n" M1.exported
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from the correct module!

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-no-group-intf.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-no-group-intf.t
@@ -19,7 +19,7 @@ Testing the bootstrap of a wrapped include subdirs qualified.
   > module M2 = A.B.X
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from wrapped a/b/x.ml
   Hello from bootstrapped binary!

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-unwrapped.t
@@ -34,7 +34,7 @@ Testing the bootstrap of an unwrapped include subdirs qualified.
   > module M3 = B.C
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from unwrapped a/b/c/c.ml
   Hello from unwrapped a/b/b.ml

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-qualified-wrapped.t
@@ -31,7 +31,7 @@ Testing the bootstrap of a wrapped include subdirs qualified.
   > module M4 = A.B.C
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from wrapped a/b/c/c.ml
   Hello from wrapped a/b/b.ml

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-unwrapped.t
@@ -30,7 +30,7 @@ Testing the bootstrap of an unwrapped include subdirs unqualified.
   > module M3 = C
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from unwrapped a/b/b.ml
   Hello from unwrapped a/b/c/c.ml

--- a/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/include-subdirs-unqualified-wrapped.t
@@ -30,7 +30,7 @@ Testing the bootstrap of a wrapped include subdirs unqualified.
   > module M4 = A.C
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from wrapped a/b/b.ml
   Hello from wrapped a/b/c/c.ml

--- a/test/blackbox-tests/test-cases/boot/ppx-expect-test.t
+++ b/test/blackbox-tests/test-cases/boot/ppx-expect-test.t
@@ -32,7 +32,7 @@ Testing that the bootstrap preprocessor strips let%expect_test blocks.
   $ create_dune a <<EOF
   > let () = Printf.printf "Hello, x = %d" A.x
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   x = 42
   Hello, x = 42

--- a/test/blackbox-tests/test-cases/boot/ppx-test-module.t
+++ b/test/blackbox-tests/test-cases/boot/ppx-test-module.t
@@ -42,7 +42,7 @@ Testing that the bootstrap preprocessor strips let%test_module blocks.
   $ create_dune a <<EOF
   > let () = Printf.printf "Hello, x = %d" A.x
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   x = 42
   Hello, x = 42

--- a/test/blackbox-tests/test-cases/boot/singleton-unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/singleton-unwrapped.t
@@ -19,7 +19,7 @@ Testing the bootstrap of singleton unwrapped libraries.
   > open B
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from singleton unwrapped a/b.ml
   Hello from bootstrapped binary!

--- a/test/blackbox-tests/test-cases/boot/singleton-wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/singleton-wrapped.t
@@ -18,7 +18,7 @@ Testing the bootstrap of singleton wrapped libraries.
   > open A
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from singleton wrapped a/a.ml
   Hello from bootstrapped binary!

--- a/test/blackbox-tests/test-cases/boot/unwrapped.t
+++ b/test/blackbox-tests/test-cases/boot/unwrapped.t
@@ -25,7 +25,7 @@ Testing the bootstrap of unwrapped libraries.
   > open B
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from unwrapped a/a.ml
   Hello from unwrapped a/b.ml

--- a/test/blackbox-tests/test-cases/boot/wrapped-no-interface.t
+++ b/test/blackbox-tests/test-cases/boot/wrapped-no-interface.t
@@ -21,7 +21,7 @@ Testing the bootstrap of wrapped libraries without interface moodule.
   > open Root
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from wrapped non-interface module a/b.ml
   Hello from bootstrapped binary!

--- a/test/blackbox-tests/test-cases/boot/wrapped.t
+++ b/test/blackbox-tests/test-cases/boot/wrapped.t
@@ -26,7 +26,7 @@ Testing the bootstrap of wrapped libraries.
   > open B
   > let () = Printf.printf "Hello from bootstrapped binary!"
   > EOF
-  ocamllex -q -o boot/pps.ml boot/pps.mll
+  ocamllex -ml -q -o boot/pps.ml boot/pps.mll
   ocaml -I +unix unix.cma $DUNEBOOT
   Hello from wrapped module a/b.ml
   Hello from wrapped interface module a/a.ml

--- a/test/blackbox-tests/test-cases/depend-on/named-binding-with-package-error.t
+++ b/test/blackbox-tests/test-cases/depend-on/named-binding-with-package-error.t
@@ -4,6 +4,17 @@ empty path list, which is rarely what the user intended.
 
   $ make_mypkg_lib_project
 
+The restriction is currently not checked when the rule is disabled:
+
+  $ cat >dune <<'EOF'
+  > (rule
+  >  (target out)
+  >  (enabled_if false)
+  >  (deps (:pkg (package mypkg)))
+  >  (action (echo unused)))
+  > EOF
+  $ dune build
+
   $ cat >dune <<'EOF'
   > (rule
   >  (deps (:pkg (package mypkg)))

--- a/test/blackbox-tests/test-cases/melange/emit-installed-melange-object-dir.t
+++ b/test/blackbox-tests/test-cases/melange/emit-installed-melange-object-dir.t
@@ -58,5 +58,5 @@ files above.
   >    | "\(.predicate) \(.dir_kind) \(.dir)"]
   >   | sort[]
   > ' deps.json
-  *.cmi External $TESTCASE_ROOT/prefix/lib/repro/foo
-  *.cmj External $TESTCASE_ROOT/prefix/lib/repro/foo
+  *.cmi External $TESTCASE_ROOT/prefix/lib/repro/foo/melange
+  *.cmj External $TESTCASE_ROOT/prefix/lib/repro/foo/melange

--- a/test/blackbox-tests/test-cases/melange/emit-installed-private-module.t
+++ b/test/blackbox-tests/test-cases/melange/emit-installed-private-module.t
@@ -57,7 +57,7 @@ stage the installed Melange object dirs rather than only the entry module's
   $ write_melange_repro_foo_consumer
 
   $ OCAMLPATH=$PWD/prefix/lib:$OCAMLPATH dune rules --format=json --deps --root app --display=quiet dist/node_modules/repro.foo/foo_map.js > deps.json
-  $ jq_dune -r '.[] | depsGlobEntriesWithPredicate("*.cmj") | select(.dir | endswith("/repro/foo")) | "\(.dir_kind) \(.dir)"' deps.json
-  External $TESTCASE_ROOT/prefix/lib/repro/foo
-  $ jq_dune -r '.[] | depsGlobEntriesWithPredicate("*.cmi") | select(.dir | endswith("/repro/foo")) | "\(.dir_kind) \(.dir)"' deps.json
-  External $TESTCASE_ROOT/prefix/lib/repro/foo
+  $ jq_dune -r '.[] | depsGlobEntriesWithPredicate("*.cmj") | select(.dir | endswith("/repro/foo/melange")) | "\(.dir_kind) \(.dir)"' deps.json
+  External $TESTCASE_ROOT/prefix/lib/repro/foo/melange
+  $ jq_dune -r '.[] | depsGlobEntriesWithPredicate("*.cmi") | select(.dir | endswith("/repro/foo/melange")) | "\(.dir_kind) \(.dir)"' deps.json
+  External $TESTCASE_ROOT/prefix/lib/repro/foo/melange

--- a/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
+++ b/test/blackbox-tests/test-cases/pkg/lock-directory-selection.t
@@ -73,9 +73,16 @@ Generate all lockdirs:
   $ dune pkg lock dune.macos.lock
   Solution for dune.macos.lock:
   - macos-only.0.0.1
-  $ dune pkg lock dune.linux.lock
+  $ DUNE_TRACE=+sat dune pkg lock dune.linux.lock
   Solution for dune.linux.lock:
   - linux-only.0.0.1
+
+The trace file is reset per dune invocation, so the assertion below
+covers only the last pkg lock above (one SAT engine run, non-portable).
+
+  $ dune trace cat \
+  > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
+  1
 
 Demonstrate that the correct lockdir is being chosen by building packages that
 are only dependent on on certain systems.

--- a/test/blackbox-tests/test-cases/pkg/lockdir-load-dedup.t
+++ b/test/blackbox-tests/test-cases/pkg/lockdir-load-dedup.t
@@ -17,9 +17,16 @@ the same lock dir.
 
   $ make_dune_project 3.23
 
-  $ dune build @check
+  $ DUNE_TRACE=+sat dune build @check
 
 Both contexts share the default lock dir. Check how many times it is loaded:
 
   $ dune trace cat | jq -s '[ .[] | select(.name == "load_lock_dir") ] | length'
   1
+
+The build path uses an already-generated lockdir, so the SAT engine
+should not run at all. With Sat tracing enabled, the count is zero.
+
+  $ dune trace cat \
+  > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
+  0

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-basic.t
@@ -17,11 +17,18 @@ Create a package that writes a different value to some files depending on the os
 
   $ make_portable_lockdirs_project
 
-  $ dune pkg lock
+  $ DUNE_TRACE=+sat dune pkg lock
   Solution for dune.lock
   
   Dependencies common to all supported platforms:
   - foo.0.0.1
+
+The portable lock directory is solved independently for each of the four
+platforms.
+
+  $ dune trace cat \
+  > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
+  4
 
   $ cat ${default_lock_dir}/lock.dune
   (lang package 0.1)

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-no-solution.t
@@ -27,7 +27,7 @@ Depend on a pair of packages which can't be coinstalled:
   > EOF
 
 Solver error when solving fails with the same error on all platforms:
-  $ dune pkg lock
+  $ DUNE_TRACE=+sat dune pkg lock
   Error:
   Unable to solve dependencies while generating lock directory: dune.lock
   
@@ -44,6 +44,12 @@ Solver error when solving fails with the same error on all platforms:
       Rejected candidates:
         c.0.2: Incompatible with restriction: = 0.1
   [1]
+
+Each of the four platform solves retries twice before reporting the failure.
+
+  $ dune trace cat \
+  > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
+  12
 
 Modify the "a" package so the solver error is different on different platforms:
   $ mkpkg a <<EOF

--- a/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
+++ b/test/blackbox-tests/test-cases/pkg/portable-lockdirs/portable-lockdirs-platform-dependant-version.t
@@ -27,7 +27,7 @@ Define a package bar which conditionally depends on different versions of foo:
 
   $ make_x_depends_bar_project
 
-  $ dune pkg lock
+  $ DUNE_TRACE=+sat dune pkg lock
   Solution for dune.lock
   
   Dependencies common to all supported platforms:
@@ -46,6 +46,13 @@ Define a package bar which conditionally depends on different versions of foo:
   
   arch = x86_64; os = macos:
   - foo.2
+
+The portable lock directory is solved independently for each of the four
+platforms.
+
+  $ dune trace cat \
+  > | jq -s 'include "dune"; [ .[] | satSolveEvents ] | length'
+  4
 
 Build the project as if we were on linux and confirm that version 1 of foo was built:
   $ export DUNE_CONFIG__OS=linux DUNE_CONFIG__ARCH=arm64 DUNE_CONFIG__OS_FAMILY=debian DUNE_CONFIG__OS_DISTRIBUTION=ubuntu DUNE_CONFIG__OS_VERSION=24.11

--- a/test/blackbox-tests/test-cases/pkg/sat-solve-trace.t
+++ b/test/blackbox-tests/test-cases/pkg/sat-solve-trace.t
@@ -27,8 +27,8 @@ Assert the shape of the `sat`/`solve` events. The exact counter values and the
 number of events depend on the solver (it may run more than once, e.g. when
 retrying with different `max_avoids`), so only assert sane ranges:
 
-  $ dune trace cat | jq -s '
-  >   [ .[] | select(.cat == "sat" and .name == "solve") ] as $solves
+  $ dune trace cat | jq -s 'include "dune";
+  >   [ .[] | satSolveEvents ] as $solves
   > | { has_sat_solve_events: ($solves | length > 0)
   >   , valid_shape: all($solves[];
   >       (.args.num_variables | type) == "number"

--- a/test/blackbox-tests/test-cases/pkg/sat-solve-trace.t
+++ b/test/blackbox-tests/test-cases/pkg/sat-solve-trace.t
@@ -1,0 +1,67 @@
+The `sat` trace category emits a complete event for every SAT solve performed
+while generating a lock directory. The events are opt-in: they are only
+emitted when the `sat` category is enabled via `DUNE_TRACE=+sat`.
+
+  $ mkrepo
+  $ mkpkg foo 0.0.1
+  $ mkpkg bar << EOF
+  > depends: [ "foo" ]
+  > EOF
+
+With the `sat` category enabled, solving emits at least one `sat`/`solve`
+event carrying the solver stats:
+
+  $ export DUNE_TRACE=+sat
+  $ solve_project << EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends bar))
+  > EOF
+  Solution for dune.lock:
+  - bar.0.0.1
+  - foo.0.0.1
+
+Assert the shape of the `sat`/`solve` events. The exact counter values and the
+number of events depend on the solver (it may run more than once, e.g. when
+retrying with different `max_avoids`), so only assert sane ranges:
+
+  $ dune trace cat | jq -s '
+  >   [ .[] | select(.cat == "sat" and .name == "solve") ] as $solves
+  > | { has_sat_solve_events: ($solves | length > 0)
+  >   , valid_shape: all($solves[];
+  >       (.args.num_variables | type) == "number"
+  >       and (.args.num_clauses | type) == "number"
+  >       and (.args.num_decisions | type) == "number"
+  >       and (.args.num_conflicts | type) == "number"
+  >       and .args.num_variables >= 1
+  >       and .args.num_clauses >= 1
+  >       and .args.num_decisions >= 0
+  >       and .args.num_conflicts >= 0
+  >       and (.dur | type) == "number")
+  >   }
+  > '
+  {
+    "has_sat_solve_events": true,
+    "valid_shape": true
+  }
+
+The `sat` category is opt-in: without `DUNE_TRACE=+sat`, no `sat` events are
+emitted at all:
+
+  $ unset DUNE_TRACE
+  $ rm -rf "${source_lock_dir}"
+  $ solve_project << EOF
+  > (lang dune 3.11)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends bar))
+  > EOF
+  Solution for dune.lock:
+  - bar.0.0.1
+  - foo.0.0.1
+
+  $ dune trace cat | jq -s '[ .[] | select(.cat == "sat") ] | length'
+  0

--- a/test/expect-tests/findlib/findlib_tests.ml
+++ b/test/expect-tests/findlib/findlib_tests.ml
@@ -50,7 +50,7 @@ let findlib =
     ; ocaml_version = Ocaml.Version.make (4, 14, 1)
     }
   in
-  Memo.lazy_ (fun () ->
+  Memo.lazy_ ~name:"findlib-for-tests" (fun () ->
     Findlib.For_tests.create ~paths:[ Path.outside_build_dir db_path ] ~lib_config)
 ;;
 

--- a/test/expect-tests/memo/deps_representation.ml
+++ b/test/expect-tests/memo/deps_representation.ml
@@ -6,7 +6,6 @@ open Test_helpers.Make ()
    series-parallel Seq/Par/Singleton/Empty structure - by driving each shape through the
    public Memo combinators and reading it back with [Memo.For_tests.get_deps_structured]. *)
 
-let leaf name = Memo.lazy_node ~name (fun () -> Memo.return ())
 let read = Memo.Node.read
 
 let print_deps label m =
@@ -18,9 +17,9 @@ let print_deps label m =
 ;;
 
 let%expect_test "dependency structure of Memo combinators" =
-  let a = leaf "a"
-  and b = leaf "b"
-  and c = leaf "c" in
+  let a = Memo.lazy_node ~name:"a" (fun () -> Memo.return ())
+  and b = Memo.lazy_node ~name:"b" (fun () -> Memo.return ())
+  and c = Memo.lazy_node ~name:"c" (fun () -> Memo.return ()) in
   (* No dependencies. *)
   print_deps "empty" (Memo.return ());
   [%expect {| empty: Empty |}];

--- a/test/expect-tests/memo/main.ml
+++ b/test/expect-tests/memo/main.ml
@@ -323,7 +323,7 @@ module Memo_lazy = Test_lazy (struct
     include Memo.Lazy
 
     (* Here we hide the optional argument [cutoff] of [Memo.Lazy.create]. *)
-    let create f = create f
+    let create f = create ~name:"test-lazy" f
   end)
 
 let%expect_test _ =
@@ -338,8 +338,8 @@ let%expect_test _ =
   Memo_lazy.deps () |> print_dyn;
   [%expect
     {|
-    (Some [ (Some "lazy_memo", "foo"); (None, ()) ],
-     Some [ (Some "lazy_memo", "foo"); (None, ()) ])
+    (Some [ (Some "lazy_memo", "foo"); (Some "test-lazy", ()) ],
+     Some [ (Some "lazy_memo", "foo"); (Some "test-lazy", ()) ])
   |}]
 ;;
 
@@ -1324,16 +1324,16 @@ let%expect_test "overlapping cycles with waiters can deadlock" =
     |}]
 ;;
 
-let lazy_rec ~name f =
+let lazy_rec f =
   let fdecl = Fdecl.create (fun _ -> Dyn.Opaque) in
-  let node = Memo.Lazy.create ~name (fun () -> f (Fdecl.get fdecl)) in
+  let node = Memo.Lazy.create ~name:"cycle" (fun () -> f (Fdecl.get fdecl)) in
   Fdecl.set fdecl node;
   node
 ;;
 
 let%expect_test "only the first cycle in a run is reported" =
-  let cycle1 = lazy_rec ~name:"cycle" (fun node -> Memo.Lazy.force node) in
-  let cycle2 = lazy_rec ~name:"cycle" (fun node -> Memo.Lazy.force node) in
+  let cycle1 = lazy_rec (fun node -> Memo.Lazy.force node) in
+  let cycle2 = lazy_rec (fun node -> Memo.Lazy.force node) in
   let both =
     Memo.Lazy.create ~name:"both" (fun () ->
       Memo.fork_and_join_unit
@@ -2190,7 +2190,7 @@ let%expect_test "Simple computation chain with a cutoff" =
 
 let%expect_test "loss of concurrency" =
   let cell name =
-    Memo.lazy_node ~cutoff:Unit.equal (fun () ->
+    Memo.lazy_node ~name:"concurrent-cell" ~cutoff:Unit.equal (fun () ->
       (* this hackery needed to observe concurrency *)
       Memo.of_reproducible_fiber
       @@ Fiber.of_thunk (fun () ->
@@ -2202,7 +2202,7 @@ let%expect_test "loss of concurrency" =
   let a = cell "a" in
   let b = cell "b" in
   let c =
-    Memo.lazy_node (fun () ->
+    Memo.lazy_node ~name:"c" (fun () ->
       Memo.fork_and_join (fun () -> Memo.Node.read a) (fun () -> Memo.Node.read b))
   in
   let read x = run @@ Memo.map ~f:ignore @@ Memo.Node.read x in
@@ -2264,7 +2264,7 @@ let%expect_test "fork_and_join: parallel cutoff restore" =
   let a, a_var = yielding_node ~name:"a" () in
   let b, b_var = yielding_node ~name:"b" () in
   let top =
-    Memo.lazy_node (fun () ->
+    Memo.lazy_node ~name:"top" (fun () ->
       printf "top* ";
       Memo.fork_and_join (fun () -> Memo.exec a ()) (fun () -> Memo.exec b ()))
   in
@@ -2293,7 +2293,7 @@ let%expect_test "parallel_map: parallel cutoff restore" =
   let a, a_var = yielding_node ~name:"a" () in
   let b, b_var = yielding_node ~name:"b" () in
   let top =
-    Memo.lazy_node (fun () ->
+    Memo.lazy_node ~name:"top" (fun () ->
       printf "top* ";
       Memo.parallel_map [ a; b ] ~f:(fun node -> Memo.exec node ()))
   in
@@ -2320,7 +2320,7 @@ let%expect_test "fork_and_join: a failing thread still lets its sibling run" =
   let a, _ = yielding_node ~name:"a" ~fail:true () in
   let b, _ = yielding_node ~name:"b" () in
   let top =
-    Memo.lazy_node (fun () ->
+    Memo.lazy_node ~name:"top" (fun () ->
       Memo.fork_and_join (fun () -> Memo.exec a ()) (fun () -> Memo.exec b ()))
   in
   run_and_log_errors (Memo.map ~f:ignore (Memo.Node.read top));
@@ -2329,8 +2329,7 @@ let%expect_test "fork_and_join: a failing thread still lets its sibling run" =
   [%expect
     {|
     a+ b+ a! b- Error: { exn =
-               "Memo.Error.E\n\
-               \  { exn = \"Failure(\\\"a\\\")\"; stack = [ (\"a\", ()); (\"<unnamed>\", ()) ] }"
+               "Memo.Error.E { exn = \"Failure(\\\"a\\\")\"; stack = [ (\"a\", ()); (\"top\", ()) ] }"
            ; backtrace = ""
            }
     |}]
@@ -2468,7 +2467,7 @@ let%expect_test "Invalidation.to_reason_list deduplicates reasons" =
 let%expect_test "reset_if_necessary" =
   let calls = ref 0 in
   let cell =
-    Memo.lazy_node (fun () ->
+    Memo.lazy_node ~name:"cell" (fun () ->
       incr calls;
       Memo.return ())
   in
@@ -2492,7 +2491,7 @@ let%expect_test "reset_if_necessary" =
 let%expect_test "reset_if_necessary retries non-reproducible errors" =
   let calls = ref 0 in
   let cell =
-    Memo.lazy_node (fun () ->
+    Memo.lazy_node ~name:"cell" (fun () ->
       incr calls;
       raise (Memo.Non_reproducible (Failure "boom")))
   in
@@ -2501,7 +2500,7 @@ let%expect_test "reset_if_necessary retries non-reproducible errors" =
   [%expect
     {|
     Error: { exn =
-               "Memo.Error.E { exn = \"Failure(\\\"boom\\\")\"; stack = [ (\"<unnamed>\", ()) ] }"
+               "Memo.Error.E { exn = \"Failure(\\\"boom\\\")\"; stack = [ (\"cell\", ()) ] }"
            ; backtrace = ""
            }
     calls = 1
@@ -2515,7 +2514,7 @@ let%expect_test "reset_if_necessary retries non-reproducible errors" =
   [%expect
     {|
     Error: { exn =
-               "Memo.Error.E { exn = \"Failure(\\\"boom\\\")\"; stack = [ (\"<unnamed>\", ()) ] }"
+               "Memo.Error.E { exn = \"Failure(\\\"boom\\\")\"; stack = [ (\"cell\", ()) ] }"
            ; backtrace = ""
            }
     calls = 2

--- a/test/expect-tests/memo/run_with_error_handler.ml
+++ b/test/expect-tests/memo/run_with_error_handler.ml
@@ -24,14 +24,18 @@ let rec delay_n_time_units counter n =
 let%expect_test "Memo.run_with_error_handler" =
   let time_counter = ref 0 in
   let error_node =
-    Memo.Lazy.create (fun () ->
+    Memo.Lazy.create ~name:"error-node" (fun () ->
       Memo.of_reproducible_fiber
         (Fiber.fork_and_join_unit
            (fun () -> Fiber.map (Scheduler.yield ()) ~f:(fun () -> failwith "Error_node"))
            (fun () -> delay_n_time_units time_counter 10)))
   in
-  let n1 = Memo.Lazy.create (fun () -> Memo.Lazy.force error_node) in
-  let n2 = Memo.Lazy.create (fun () -> Memo.Lazy.force error_node) in
+  let n1 =
+    Memo.Lazy.create ~name:"error-node-wrapper-1" (fun () -> Memo.Lazy.force error_node)
+  in
+  let n2 =
+    Memo.Lazy.create ~name:"error-node-wrapper-2" (fun () -> Memo.Lazy.force error_node)
+  in
   let run_memo_and_collect_errors m =
     let trace = ref [] in
     let log s = trace := (s, !time_counter) :: !trace in

--- a/test/expect-tests/sat/dune
+++ b/test/expect-tests/sat/dune
@@ -1,0 +1,15 @@
+(library
+ (name dune_sat_unit_tests)
+ (inline_tests)
+ (libraries
+  dune_tests_common
+  stdune
+  sat
+  ;; This is because of the (implicit_transitive_deps false)
+  ;; in dune-project
+  ppx_expect.config
+  ppx_expect.config_types
+  base
+  ppx_inline_test.config)
+ (preprocess
+  (pps ppx_expect)))

--- a/test/expect-tests/sat/sat_tests.ml
+++ b/test/expect-tests/sat/sat_tests.ml
@@ -1,0 +1,138 @@
+open Stdune
+open Dune_tests_common
+
+let () = init ()
+
+module Sat = Sat.Make (struct
+    type t = int
+
+    let pp = Pp.textf "%d"
+  end)
+
+let print_stats p =
+  let open Sat in
+  let st = get_stats p in
+  Format.printf
+    "num_variables=%d num_clauses=%d num_decisions=%d num_conflicts=%d@."
+    st.num_variables
+    st.num_clauses
+    st.num_decisions
+    st.num_conflicts
+;;
+
+let is_some = function
+  | Some _ -> true
+  | None -> false
+;;
+
+let%expect_test "a fresh problem has all-zero stats" =
+  let open Sat in
+  let p = create () in
+  print_stats p;
+  [%expect
+    {|
+    num_variables=0 num_clauses=0 num_decisions=0 num_conflicts=0
+  |}]
+;;
+
+let%expect_test "structural counters track added variables and input clauses" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let b = add_variable p 2 in
+  let c = add_variable p 3 in
+  print_stats p;
+  at_least_one p [ a; b ];
+  implies p b [ c ];
+  print_stats p;
+  impossible p;
+  print_stats p;
+  [%expect
+    {|
+    num_variables=3 num_clauses=0 num_decisions=0 num_conflicts=0
+    num_variables=3 num_clauses=2 num_decisions=0 num_conflicts=0
+    num_variables=3 num_clauses=3 num_decisions=0 num_conflicts=0
+  |}]
+;;
+
+let%expect_test "at-most clauses are not counted in num_clauses" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let b = add_variable p 2 in
+  let c = add_variable p 3 in
+  let amo = at_most_one [ a; b ] in
+  let _am2 = at_most 2 [ a; b; c ] in
+  print_stats p;
+  (* The at-most clauses are real even though they are not counted:
+     nothing is selected yet, and [a] is still undecided. *)
+  print_endline (if is_some (get_selected amo) then "selected" else "unselected");
+  print_endline (if is_some (get_best_undecided amo) then "undecided" else "decided");
+  [%expect
+    {|
+    num_variables=3 num_clauses=0 num_decisions=0 num_conflicts=0
+    unselected
+    undecided
+  |}]
+;;
+
+let%expect_test "run_solver records decisions, and counters are cumulative" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let b = add_variable p 2 in
+  at_least_one p [ a; b ];
+  let amo = at_most_one [ a; b ] in
+  let decide () = get_best_undecided amo in
+  print_endline (string_of_bool (run_solver p decide));
+  print_stats p;
+  (* Re-solving the same (already solved) problem is a no-op: all
+     variables are decided, so no new decisions or conflicts happen. *)
+  print_endline (string_of_bool (run_solver p decide));
+  print_stats p;
+  print_endline (if is_some (get_selected amo) then "selected" else "unselected");
+  [%expect
+    {|
+    true
+    num_variables=2 num_clauses=1 num_decisions=1 num_conflicts=0
+    true
+    num_variables=2 num_clauses=1 num_decisions=1 num_conflicts=0
+    selected
+  |}]
+;;
+
+let%expect_test "impossible problems are rejected before solving" =
+  let open Sat in
+  let p = create () in
+  impossible p;
+  print_stats p;
+  print_endline (string_of_bool (run_solver p (fun () -> None)));
+  print_stats p;
+  [%expect
+    {|
+    num_variables=0 num_clauses=1 num_decisions=0 num_conflicts=0
+    false
+    num_variables=0 num_clauses=1 num_decisions=0 num_conflicts=0
+  |}]
+;;
+
+let%expect_test "run_solver records conflicts on an unsatisfiable problem" =
+  let open Sat in
+  let p = create () in
+  let a = add_variable p 1 in
+  let b = add_variable p 2 in
+  (* (a or b) and (!a or b) and (a or !b) and (!a or !b) is unsatisfiable. *)
+  at_least_one p [ a; b ];
+  at_least_one p [ neg a; b ];
+  at_least_one p [ a; neg b ];
+  at_least_one p [ neg a; neg b ];
+  (* Returning [None] from the decider means: set the remaining variables
+     to [False]. The search then discovers both conflicts. *)
+  print_endline (string_of_bool (run_solver p (fun () -> None)));
+  print_stats p;
+  [%expect
+    {|
+    false
+    num_variables=2 num_clauses=4 num_decisions=1 num_conflicts=2
+  |}]
+;;


### PR DESCRIPTION
Use `Obj_dir.all_obj_dirs ~mode:Melange` when constructing Melange emission include paths.

Depends on ocaml/dune#15949.