### PR TITLE
fix(obj-dir): include external OCaml public CMI directory

### DIFF
--- a/src/dune_rules/obj_dir.ml
+++ b/src/dune_rules/obj_dir.ml
@@ -155,12 +155,11 @@ module External = struct
   let odoc_dir t = t.public_dir.ocaml
 
   let all_obj_dirs t ~(mode : Lib_mode.t) =
-    match mode with
-    | Ocaml _ -> [ t.public_dir.ocaml ]
-    | Melange ->
-      [ t.public_dir.melange; public_cmi_melange_dir t ]
-      |> Path.Set.of_list
-      |> Path.Set.to_list
+    (match mode with
+     | Ocaml _ -> [ t.public_dir.ocaml; public_cmi_ocaml_dir t ]
+     | Melange -> [ t.public_dir.melange; public_cmi_melange_dir t ])
+    |> Path.Set.of_list
+    |> Path.Set.to_list
   ;;
 
   let all_cmis { public_dir; private_dir; public_cmi_dir } =

--- a/test/expect-tests/obj_dir_tests.ml
+++ b/test/expect-tests/obj_dir_tests.ml
@@ -29,8 +29,8 @@ let%expect_test "external object directories with dedicated public CMI directori
        ]);
   [%expect
     {|
-    { ocaml byte = [ "prefix/lib/foo" ]
-    ; ocaml native = [ "prefix/lib/foo" ]
+    { ocaml byte = [ "prefix/lib/foo"; "prefix/lib/foo/.public_cmi" ]
+    ; ocaml native = [ "prefix/lib/foo"; "prefix/lib/foo/.public_cmi" ]
     ; melange =
         [ "prefix/lib/foo/melange"
         ; "prefix/lib/foo/melange/.public_cmi_melange"


### PR DESCRIPTION
Include dedicated public CMI directories in external OCaml object-directory sets.

Stacked on ocaml/dune#15969.