### PR TITLE
refactor(melange): share JS output components

### DIFF
--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -84,31 +84,28 @@ let lib_output_path ~output_dir ~lib_dir src =
     Path.Build.append_local output_dir src_dir)
 ;;
 
-let make_js_name ~js_ext ~output m =
-  let dst_dir =
-    let src_dir =
-      Module.source m ~ml_kind:Impl
-      |> Option.value_exn
-      |> Module.File.original_path
-      |> Path.parent_exn
-    in
-    match output with
-    | Output_kind.Public_library { lib_dir; target_dir; output_dir } ->
-      let output_dir = Path.Build.append_local target_dir output_dir in
-      lib_output_path ~output_dir ~lib_dir src_dir
-    | Private_library_or_emit target_dir ->
-      Melange.output_path ~target_dir (Path.as_in_build_dir_exn src_dir)
-  in
-  let basename =
-    Filename.to_string (Module_compilation.melange_js_basename m)
-    ^ Filename.Extension.to_string js_ext
-  in
-  Path.Build.relative dst_dir basename
-;;
-
 let js_outputs_of_module ~module_systems ~output m =
-  List.map module_systems ~f:(fun (module_system, js_ext) ->
-    module_system, make_js_name ~js_ext ~output m)
+  match module_systems with
+  | [] -> []
+  | _ ->
+    let dst_dir =
+      let src_dir =
+        Module.source m ~ml_kind:Impl
+        |> Option.value_exn
+        |> Module.File.original_path
+        |> Path.parent_exn
+      in
+      match output with
+      | Output_kind.Public_library { lib_dir; target_dir; output_dir } ->
+        let output_dir = Path.Build.append_local target_dir output_dir in
+        lib_output_path ~output_dir ~lib_dir src_dir
+      | Private_library_or_emit target_dir ->
+        Melange.output_path ~target_dir (Path.as_in_build_dir_exn src_dir)
+    in
+    let basename = Module_compilation.melange_js_basename m |> Filename.to_string in
+    List.map module_systems ~f:(fun (module_system, js_ext) ->
+      let basename = basename ^ Filename.Extension.to_string js_ext in
+      module_system, Path.Build.relative dst_dir basename)
 ;;
 
 let modules_in_obj_dir ~sctx ~scope ~preprocess modules =

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -87,7 +87,7 @@ let lib_output_path ~output_dir ~lib_dir src =
 let js_outputs_of_module ~module_systems ~output m =
   match module_systems with
   | [] -> []
-  | _ ->
+  | _ :: _ ->
     let dst_dir =
       let src_dir =
         Module.source m ~ml_kind:Impl


### PR DESCRIPTION
Compute each module’s JavaScript output directory and basename once across all configured module systems.