### PR TITLE
refactor(rules): share unused library setup

### DIFF
--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -241,18 +241,7 @@ let executables_rules
   let lib_config = ocaml.lib_config in
   let* requires_compile = Compilation_context.requires_compile cctx in
   let* () =
-    let toolchain = Compilation_context.ocaml cctx in
-    let user_written_requires = Lib.Compile.user_written_requires compile_info ~for_ in
-    let allow_unused_libraries = Lib.Compile.allow_unused_libraries compile_info in
-    Unused_libs_rules.gen_rules
-      sctx
-      toolchain
-      exes.buildable.loc
-      ~obj_dir
-      ~modules
-      ~dir
-      ~user_written_requires
-      ~allow_unused_libraries
+    Unused_libs_rules.gen_rules_for_context cctx compile_info ~loc:exes.buildable.loc
   in
   let* () =
     let* dep_graphs =

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -634,18 +634,7 @@ let library_rules
       ; for_
       }
   and+ () =
-    let toolchain = Compilation_context.ocaml cctx in
-    let user_written_requires = Lib.Compile.user_written_requires compile_info ~for_ in
-    let allow_unused_libraries = Lib.Compile.allow_unused_libraries compile_info in
-    Unused_libs_rules.gen_rules
-      sctx
-      toolchain
-      lib.buildable.loc
-      ~obj_dir
-      ~modules
-      ~dir
-      ~user_written_requires
-      ~allow_unused_libraries
+    Unused_libs_rules.gen_rules_for_context cctx compile_info ~loc:lib.buildable.loc
   and+ merlin =
     let+ requires_hidden = Compilation_context.requires_hidden cctx
     and+ parameters = Compilation_context.parameters cctx in

--- a/src/dune_rules/unused_libs_rules.ml
+++ b/src/dune_rules/unused_libs_rules.ml
@@ -116,3 +116,23 @@ let gen_rules
       ~loc
       (action |> Action_builder.map ~f:Action.Full.make)
 ;;
+
+let gen_rules_for_context cctx compile_info ~loc =
+  let sctx = Compilation_context.super_context cctx in
+  let toolchain = Compilation_context.ocaml cctx in
+  let for_ = Compilation_context.for_ cctx in
+  let obj_dir = Compilation_context.obj_dir cctx in
+  let modules = Compilation_context.modules cctx in
+  let dir = Compilation_context.dir cctx in
+  let user_written_requires = Lib.Compile.user_written_requires compile_info ~for_ in
+  let allow_unused_libraries = Lib.Compile.allow_unused_libraries compile_info in
+  gen_rules
+    sctx
+    toolchain
+    loc
+    ~obj_dir
+    ~modules
+    ~dir
+    ~user_written_requires
+    ~allow_unused_libraries
+;;

--- a/src/dune_rules/unused_libs_rules.mli
+++ b/src/dune_rules/unused_libs_rules.mli
@@ -1,12 +1,7 @@
 open Import
 
-val gen_rules
-  :  Super_context.t
-  -> Ocaml_toolchain.t
-  -> Loc.t
-  -> obj_dir:Path.Build.t Obj_dir.t
-  -> modules:Modules.With_vlib.t
-  -> dir:Path.Build.t
-  -> user_written_requires:(Loc.t * Lib.t) list Resolve.Memo.t
-  -> allow_unused_libraries:Lib.t list Resolve.Memo.t
+val gen_rules_for_context
+  :  Compilation_context.t
+  -> Lib.Compile.t
+  -> loc:Loc.t
   -> unit Memo.t


### PR DESCRIPTION
Centralize unused-library rule setup shared by library and executable compilation contexts.