### PR TITLE
refactor(mdx): reuse resolved OCaml toolchain

### DIFF
--- a/src/dune_rules/mdx.ml
+++ b/src/dune_rules/mdx.ml
@@ -424,16 +424,11 @@ let mdx_prog_gen t ~sctx ~dir ~scope ~mdx_prog =
             let+ lib = Lib.DB.resolve (Scope.libs scope) lib in
             Some lib
           | _ -> Resolve.Memo.return None)
-      and+ lib_config =
-        Resolve.Memo.lift_memo
-        @@ Memo.O.(
-             let+ ocaml = Super_context.context sctx |> Context.ocaml in
-             ocaml.lib_config)
       in
       let mode = ocaml_toolchain |> Ocaml_toolchain.best_mode in
       let open Command.Args in
       S
-        (Lib_flags.L.include_paths libs_to_include (Ocaml mode) lib_config
+        (Lib_flags.L.include_paths libs_to_include (Ocaml mode) ocaml_toolchain.lib_config
          |> Lib_flags.L.include_only
          |> List.map ~f:(fun p -> S [ A "--directory"; Path p ]))
     in


### PR DESCRIPTION
Reuse the resolved OCaml toolchain for MDX mode and library include paths.