### PR TITLE
fix(melange): read imported virtual-library dependencies from CMTs

### DIFF
--- a/doc/changes/fixed/16211.md
+++ b/doc/changes/fixed/16211.md
@@ -1,0 +1,3 @@
+- Fix compiling Melange implementations of installed virtual libraries with
+  binary annotations, including transitive private module dependencies
+  (#16211, @anmonteiro)

--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -153,45 +153,53 @@ let ooi_deps
       ~sctx
       ~dir
       ~obj_dir
+      ~vlib_obj_dir
       ~dune_version
       ~vlib_obj_map
-      ~(ml_kind : Ml_kind.t)
+      ~(for_ : Compilation_mode.t)
       (sourced_module : Modules.Sourced_module.t)
+      ~(ml_kind : Ml_kind.t)
   =
   let m = Modules.Sourced_module.to_module sourced_module in
-  let+ read =
-    let unit =
-      let cm_kind =
-        match ml_kind with
-        | Intf -> Cm_kind.Cmi
-        | Impl -> vimpl |> Vimpl.impl_cm_kind
-      in
-      Obj_dir.Module.cm_file_exn obj_dir m ~kind:(Ocaml cm_kind) |> Path.build
-    in
-    let sandbox =
-      if dune_version >= (3, 3) then Some Sandbox_config.needs_sandboxing else None
-    in
-    let+ ocaml =
-      let ctx = Super_context.context sctx in
-      Context.ocaml ctx
-    in
+  let sandbox =
+    if dune_version >= (3, 3) then Some Sandbox_config.needs_sandboxing else None
+  in
+  let+ ocaml = Context.ocaml (Super_context.context sctx) in
+  let read unit =
     Ocamlobjinfo.rules ocaml ~sandbox ~dir ~units:[ unit ]
     |> Action_builder.map ~f:(function
       | [ x ] -> x
       | [] | _ :: _ -> assert false)
+    |> Action_builder.memoize "ocamlobjinfo"
+    |> Action_builder.map ~f:(fun (ooi : Ocamlobjinfo.t) ->
+      Module_name.Unique.Set.to_list ooi.intf
+      |> List.filter_map ~f:(fun dep ->
+        if Module.obj_name m = dep
+        then None
+        else
+          Module_name.Unique.Map.find vlib_obj_map dep
+          |> Option.map ~f:Modules.Sourced_module.to_module))
   in
-  let read =
-    Action_builder.memoize
-      "ocamlobjinfo"
-      (let open Action_builder.O in
-       let+ (ooi : Ocamlobjinfo.t) = read in
-       Module_name.Unique.Set.to_list ooi.intf
-       |> List.filter_map ~f:(fun dep ->
-         if Module.obj_name m = dep
-         then None
-         else Module_name.Unique.Map.find vlib_obj_map dep))
+  let read_copied kind =
+    Obj_dir.Module.cm_file_exn obj_dir m ~kind |> Path.build |> read
   in
-  read
+  match ml_kind with
+  | Intf ->
+    read_copied
+      (match for_ with
+       | Ocaml -> Lib_mode.Cm_kind.Ocaml Cmi
+       | Melange -> Melange Cmi)
+  | Impl ->
+    let ocaml_deps = read_copied (Ocaml (Vimpl.impl_cm_kind vimpl)) in
+    (match for_ with
+     | Ocaml -> ocaml_deps
+     | Melange ->
+       (match
+          Obj_dir.Module.cmt_file vlib_obj_dir m ~ml_kind:Impl ~cm_kind:(Melange Cmj)
+        with
+        | None -> ocaml_deps
+        | Some cmt ->
+          Action_builder.if_file_exists cmt ~then_:(read cmt) ~else_:ocaml_deps))
 ;;
 
 let wrapped_compat_deps modules m =
@@ -219,7 +227,12 @@ let preprocessed_modules_of_local_lib ~sctx lib ~for_ =
 ;;
 
 type imported_vlib_deps =
-  Modules.Sourced_module.t -> ml_kind:Ml_kind.t -> Module.t list Action_builder.t Memo.t
+  { deps_of :
+      Modules.Sourced_module.t
+      -> ml_kind:Ml_kind.t
+      -> Module.t list Action_builder.t Memo.t
+  ; impl_deps_are_immediate : bool
+  }
 
 type memoized_transitive_deps =
   { output : Transitive_deps_output.t
@@ -318,10 +331,27 @@ and transitive_deps_output_of_imported_vlib t m ~ml_kind =
     let open Action_builder.O in
     let* deps =
       Action_builder.of_memo
-        (imported_vlib_deps (Modules.Sourced_module.Imported_from_vlib m) ~ml_kind)
+        (imported_vlib_deps.deps_of
+           (Modules.Sourced_module.Imported_from_vlib m)
+           ~ml_kind)
     in
-    let+ deps = deps in
-    Transitive_deps_output.of_modules deps
+    let* deps = deps in
+    (match ml_kind, imported_vlib_deps.impl_deps_are_immediate with
+     | Intf, _ | Impl, false ->
+       Transitive_deps_output.of_modules deps |> Action_builder.return
+     | Impl, true ->
+       let transitive =
+         List.filter_map deps ~f:(fun dep ->
+           match Module.kind dep with
+           | Root | Alias _ -> None
+           | _ ->
+             let ml_kind = if Module.has dep ~ml_kind:Impl then Ml_kind.Impl else Intf in
+             Some
+               (Action_builder.exec_memo (Lazy.force t.memo) (Module.obj_name dep, ml_kind)
+                |> Action_builder.map ~f:(fun memoized -> memoized.output)))
+       in
+       let immediate = List.map deps ~f:Module.obj_name in
+       Transitive_deps_output.merge ~dir:t.dir ~transitive ~immediate)
 ;;
 
 let transitive_deps_of t ~ml_kind unit =
@@ -346,26 +376,26 @@ let make_imported_vlib_deps ~obj_dir ~vimpl ~dir ~sctx ~sandbox ~for_ : imported
   match Lib.Local.of_lib vlib with
   | None ->
     let vlib_obj_map = Vimpl.vlib_obj_map vimpl in
+    let vlib_obj_dir = Lib.info vlib |> Lib_info.obj_dir in
     let dune_version =
       let impl = Vimpl.impl vimpl in
       Dune_project.dune_version impl.project
     in
-    let deps_of sourced_module ~ml_kind =
-      let+ deps =
+    { deps_of =
         ooi_deps
           ~vimpl
           ~sctx
           ~dir
           ~obj_dir
+          ~vlib_obj_dir
           ~dune_version
           ~vlib_obj_map
-          ~ml_kind
-          sourced_module
-      in
-      Action_builder.map deps ~f:(fun deps ->
-        List.map deps ~f:Modules.Sourced_module.to_module)
-    in
-    deps_of
+          ~for_
+    ; impl_deps_are_immediate =
+        (match for_ with
+         | Ocaml -> false
+         | Melange -> true)
+    }
   | Some lib ->
     let vlib_obj_dir =
       let info = Lib.Local.info lib in
@@ -388,7 +418,7 @@ let make_imported_vlib_deps ~obj_dir ~vimpl ~dir ~sctx ~sandbox ~for_ : imported
       let m = Modules.Sourced_module.to_module sourced_module in
       transitive_deps_of transitive_deps ~ml_kind m |> Memo.return
     in
-    deps_of
+    { deps_of; impl_deps_are_immediate = false }
 ;;
 
 let make_transitive_deps ~obj_dir ~modules ~sandbox ~impl ~dir ~sctx ~for_ =
@@ -457,7 +487,7 @@ let rec deps_of
        | None -> Code_error.raise "imported vlib module without vlib deps" []
        | Some imported_vlib_deps ->
          skip_if_source_absent
-           (fun sourced_module -> imported_vlib_deps sourced_module ~ml_kind)
+           (fun sourced_module -> imported_vlib_deps.deps_of sourced_module ~ml_kind)
            m)
     | Normal _ ->
       skip_if_source_absent

--- a/src/dune_rules/ocamlobjinfo.mll
+++ b/src/dune_rules/ocamlobjinfo.mll
@@ -24,6 +24,7 @@ let name = ['A'-'Z'] ['A'-'Z' 'a'-'z' '0'-'9' '_']*
 
 rule ocamlobjinfo acc_units acc = parse
   | "Interfaces imported:" newline { intfs acc_units acc lexbuf }
+  | "Cmt interfaces imported:" newline { intfs acc_units acc lexbuf }
   | "Implementations imported:" newline { impls acc_units acc lexbuf }
   | _ { ocamlobjinfo acc_units acc lexbuf }
   | eof { acc :: acc_units }

--- a/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
@@ -75,11 +75,6 @@ The virtual library and its implementation are both Melange-only.
 
   $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
   > dune build --root consumer --sandbox=symlink @melange
-  Entering directory 'consumer'
-  File "impl/.impl.objs/melange/_unknown_", line 1, characters 0-0:
-  Error: No rule found for impl/.impl.objs/native/vlib__Shared.cmx
-  Leaving directory 'consumer'
-  [1]
 
 With annotations, dependency analysis should read the precise imports from the
 CMT, including private modules but excluding unused ones.
@@ -87,12 +82,6 @@ CMT, including private modules but excluding unused ones.
   $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
   > dune rules --root consumer --recursive --format=json --deps --display=quiet \
   > impl/.impl.objs/melange/vlib__Virt.cmj > deps.json
-  Entering directory 'consumer'
-  Error: No rule found for impl/.impl.objs/native/vlib__Shared.cmx
-  -> required by transitive deps of vlib__Shared.impl in _build/default/impl
-  -> required by transitive deps of vlib__Virt.impl in _build/default/impl
-  Leaving directory 'consumer'
-  [1]
   $ jq_dune -r '
   >   [.[] | depsFilePaths
   >    | select(endswith("vlib__Helper.cmi")
@@ -108,3 +97,10 @@ CMT, including private modules but excluding unused ones.
   >    | select(startswith("_build/default/impl/.impl.objs/melange/"))]
   >   | unique[]
   > ' deps.json
+  _build/default/impl/.impl.objs/melange/vlib__Helper.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Helper.cmj
+  _build/default/impl/.impl.objs/melange/vlib__Leaf.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Leaf.cmj
+  _build/default/impl/.impl.objs/melange/vlib__Other.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Other.cmj
+  _build/default/impl/.impl.objs/melange/vlib__Virt.cmi


### PR DESCRIPTION
Read installed Melange virtual-library implementation dependencies from CMTs, including transitive private dependencies.

Follow-up to ocaml/dune#16066. The no-CMT fallback remains in #58.