### PR TITLE
test(melange): cover imported virtual libraries without CMTs

### DIFF
--- a/src/dune_rules/dep_rules.ml
+++ b/src/dune_rules/dep_rules.ml
@@ -153,45 +153,50 @@ let ooi_deps
       ~sctx
       ~dir
       ~obj_dir
+      ~vlib_obj_dir
       ~dune_version
       ~vlib_obj_map
+      ~(for_ : Compilation_mode.t)
       ~(ml_kind : Ml_kind.t)
       (sourced_module : Modules.Sourced_module.t)
   =
   let m = Modules.Sourced_module.to_module sourced_module in
-  let+ read =
-    let unit =
-      let cm_kind =
-        match ml_kind with
-        | Intf -> Cm_kind.Cmi
-        | Impl -> vimpl |> Vimpl.impl_cm_kind
-      in
-      Obj_dir.Module.cm_file_exn obj_dir m ~kind:(Ocaml cm_kind) |> Path.build
-    in
-    let sandbox =
-      if dune_version >= (3, 3) then Some Sandbox_config.needs_sandboxing else None
-    in
-    let+ ocaml =
-      let ctx = Super_context.context sctx in
-      Context.ocaml ctx
-    in
+  let sandbox =
+    if dune_version >= (3, 3) then Some Sandbox_config.needs_sandboxing else None
+  in
+  let+ ocaml =
+    let ctx = Super_context.context sctx in
+    Context.ocaml ctx
+  in
+  let read unit =
     Ocamlobjinfo.rules ocaml ~sandbox ~dir ~units:[ unit ]
     |> Action_builder.map ~f:(function
       | [ x ] -> x
       | [] | _ :: _ -> assert false)
+    |> Action_builder.memoize "ocamlobjinfo"
+    |> Action_builder.map ~f:(fun (ooi : Ocamlobjinfo.t) ->
+      Module_name.Unique.Set.to_list ooi.intf
+      |> List.filter_map ~f:(fun dep ->
+        if Module.obj_name m = dep
+        then None
+        else
+          Module_name.Unique.Map.find vlib_obj_map dep
+          |> Option.map ~f:Modules.Sourced_module.to_module))
   in
-  let read =
-    Action_builder.memoize
-      "ocamlobjinfo"
-      (let open Action_builder.O in
-       let+ (ooi : Ocamlobjinfo.t) = read in
-       Module_name.Unique.Set.to_list ooi.intf
-       |> List.filter_map ~f:(fun dep ->
-         if Module.obj_name m = dep
-         then None
-         else Module_name.Unique.Map.find vlib_obj_map dep))
-  in
-  read
+  match for_, ml_kind with
+  | Ocaml, Intf ->
+    Obj_dir.Module.cm_file_exn obj_dir m ~kind:(Ocaml Cmi) |> Path.build |> read
+  | Ocaml, Impl ->
+    let cm_kind = Vimpl.impl_cm_kind vimpl in
+    Obj_dir.Module.cm_file_exn obj_dir m ~kind:(Ocaml cm_kind) |> Path.build |> read
+  | Melange, Intf ->
+    Obj_dir.Module.cm_file_exn obj_dir m ~kind:(Melange Cmi) |> Path.build |> read
+  | Melange, Impl ->
+    let cmt =
+      Obj_dir.Module.cmt_file vlib_obj_dir m ~ml_kind:Impl ~cm_kind:(Melange Cmj)
+      |> Option.value_exn
+    in
+    Action_builder.if_file_exists cmt ~then_:(read cmt) ~else_:(Action_builder.return [])
 ;;
 
 let wrapped_compat_deps modules m =
@@ -341,30 +346,36 @@ let transitive_deps_of t ~ml_kind unit =
             (Ml_kind.to_string ml_kind))
 ;;
 
-let make_imported_vlib_deps ~obj_dir ~vimpl ~dir ~sctx ~sandbox ~for_ : imported_vlib_deps
+let make_imported_vlib_deps
+      ~obj_dir
+      ~vimpl
+      ~dir
+      ~sctx
+      ~sandbox
+      ~(for_ : Compilation_mode.t)
+  : imported_vlib_deps
   =
   let vlib = Vimpl.vlib vimpl in
   match Lib.Local.of_lib vlib with
   | None ->
     let vlib_obj_map = Vimpl.vlib_obj_map vimpl in
+    let vlib_obj_dir = Lib.info vlib |> Lib_info.obj_dir in
     let dune_version =
       let impl = Vimpl.impl vimpl in
       Dune_project.dune_version impl.project
     in
     let deps_of sourced_module ~ml_kind =
-      let+ deps =
-        ooi_deps
-          ~vimpl
-          ~sctx
-          ~dir
-          ~obj_dir
-          ~dune_version
-          ~vlib_obj_map
-          ~ml_kind
-          sourced_module
-      in
-      Action_builder.map deps ~f:(fun deps ->
-        List.map deps ~f:Modules.Sourced_module.to_module)
+      ooi_deps
+        ~vimpl
+        ~sctx
+        ~dir
+        ~obj_dir
+        ~vlib_obj_dir
+        ~dune_version
+        ~vlib_obj_map
+        ~for_
+        ~ml_kind
+        sourced_module
     in
     deps_of
   | Some lib ->

--- a/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps-no-cmt.t
+++ b/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps-no-cmt.t
@@ -1,0 +1,98 @@
+An implementation of an installed Melange virtual library must conservatively
+stage copied objects when binary annotations are unavailable.
+
+  $ mkdir -p producer/vlib consumer/impl
+
+  $ cat > producer/dune-project <<'EOF'
+  > (lang dune 3.24)
+  > (using melange 1.0)
+  > (package (name repro))
+  > EOF
+  $ cat > producer/vlib/dune <<'EOF'
+  > (library
+  >  (name vlib)
+  >  (public_name repro.vlib)
+  >  (modes melange)
+  >  (private_modules helper unused)
+  >  (virtual_modules virt reverse))
+  > (env
+  >  (_
+  >   (bin_annot false)))
+  > EOF
+  $ cat > producer/vlib/virt.mli <<'EOF'
+  > val run : unit -> unit
+  > EOF
+  $ cat > producer/vlib/reverse.mli <<'EOF'
+  > val answer : int
+  > EOF
+  $ cat > producer/vlib/shared.ml <<'EOF'
+  > let answer = Helper.answer
+  > EOF
+  $ cat > producer/vlib/helper.ml <<'EOF'
+  > type t = int
+  > let answer = 42
+  > EOF
+  $ cat > producer/vlib/helper.mli <<'EOF'
+  > type t
+  > val answer : t
+  > EOF
+  $ cat > producer/vlib/unused.ml <<'EOF'
+  > let ignored = 0
+  > EOF
+
+  $ dune build --root producer @install
+  $ dune install --root producer --prefix "$PWD/prefix"
+  $ test ! -e "$PWD/prefix/lib/repro/vlib/melange/vlib__Shared.cmt"
+  $ test -e "$PWD/prefix/lib/repro/vlib/melange/.private/vlib__Helper.cmi"
+  $ test ! -e "$PWD/prefix/lib/repro/vlib/melange/.private/vlib__Helper.cmt"
+
+  $ cat > consumer/dune-project <<'EOF'
+  > (lang dune 3.24)
+  > (using melange 1.0)
+  > (package (name consumer))
+  > EOF
+  $ cat > consumer/impl/dune <<'EOF'
+  > (library
+  >  (name impl)
+  >  (public_name consumer.impl)
+  >  (modes melange)
+  >  (implements repro.vlib))
+  > EOF
+  $ cat > consumer/impl/virt.ml <<'EOF'
+  > let run () = ignore Shared.answer
+  > EOF
+
+Reverse depends on Virt in the opposite direction. Conservative staging must
+not turn copied artifacts into a Virt-to-Reverse module dependency cycle.
+
+  $ cat > consumer/impl/reverse.ml <<'EOF'
+  > let answer = Virt.run (); 0
+  > EOF
+  $ cat > consumer/dune <<'EOF'
+  > (melange.emit
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (compile_flags :standard --mel-cross-module-opt)
+  >  (libraries impl))
+  > EOF
+
+  $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
+  > dune build --root consumer --sandbox=symlink @melange
+
+  $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
+  > dune rules --root consumer --recursive --format=json --deps --display=quiet \
+  > impl/.impl.objs/melange/vlib__Virt.cmj > deps.json
+  $ jq_dune -r '
+  >   [.[] | depsFilePaths
+  >    | select(endswith("vlib__Helper.cmi")
+  >             or endswith("vlib__Helper.cmj")
+  >             or endswith("vlib__Reverse.cmi")
+  >             or endswith("vlib__Reverse.cmj")
+  >             or endswith("vlib__Unused.cmi")
+  >             or endswith("vlib__Unused.cmj")
+  >             or endswith("vlib__Virt.cmi")
+  >             or endswith("vlib__Virt.cmj"))
+  >    | select(startswith("_build/default/impl/.impl.objs/melange/"))]
+  >   | unique[]
+  > ' deps.json
+  _build/default/impl/.impl.objs/melange/vlib__Virt.cmi

--- a/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
@@ -72,11 +72,6 @@ The virtual library and its implementation are both Melange-only.
 
   $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
   > dune build --root consumer --sandbox=symlink @melange
-  Entering directory 'consumer'
-  File "impl/.impl.objs/melange/_unknown_", line 1, characters 0-0:
-  Error: No rule found for impl/.impl.objs/native/vlib__Shared.cmx
-  Leaving directory 'consumer'
-  [1]
 
 With annotations, dependency analysis should read the precise imports from the
 CMT, including private modules but excluding unused ones.
@@ -84,12 +79,6 @@ CMT, including private modules but excluding unused ones.
   $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
   > dune rules --root consumer --recursive --format=json --deps --display=quiet \
   > impl/.impl.objs/melange/vlib__Virt.cmj > deps.json
-  Entering directory 'consumer'
-  Error: No rule found for impl/.impl.objs/native/vlib__Shared.cmx
-  -> required by transitive deps of vlib__Shared.impl in _build/default/impl
-  -> required by transitive deps of vlib__Virt.impl in _build/default/impl
-  Leaving directory 'consumer'
-  [1]
   $ jq_dune -r '
   >   [.[] | depsFilePaths
   >    | select(endswith("vlib__Helper.cmi")
@@ -105,3 +94,10 @@ CMT, including private modules but excluding unused ones.
   >    | select(startswith("_build/default/impl/.impl.objs/melange/"))]
   >   | unique[]
   > ' deps.json
+  _build/default/impl/.impl.objs/melange/vlib__Helper.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Helper.cmj
+  _build/default/impl/.impl.objs/melange/vlib__Leaf.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Leaf.cmj
+  _build/default/impl/.impl.objs/melange/vlib__Other.cmi
+  _build/default/impl/.impl.objs/melange/vlib__Other.cmj
+  _build/default/impl/.impl.objs/melange/vlib__Virt.cmi

--- a/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
+++ b/test/blackbox-tests/test-cases/melange/installed-virtual-lib-deps.t
@@ -16,17 +16,33 @@ The virtual library and its implementation are both Melange-only.
   >  (name vlib)
   >  (public_name repro.vlib)
   >  (modes melange)
-  >  (virtual_modules virt))
+  >  (private_modules helper leaf unused)
+  >  (virtual_modules virt other))
   > EOF
   $ cat > producer/vlib/virt.mli <<'EOF'
   > val run : unit -> int
   > EOF
+  $ cat > producer/vlib/other.mli <<'EOF'
+  > val run : unit -> int
+  > EOF
   $ cat > producer/vlib/shared.ml <<'EOF'
+  > let answer = Helper.answer + Other.run ()
+  > EOF
+  $ cat > producer/vlib/helper.ml <<'EOF'
+  > let answer = Leaf.answer
+  > EOF
+  $ cat > producer/vlib/leaf.ml <<'EOF'
   > let answer = 42
+  > EOF
+  $ cat > producer/vlib/unused.ml <<'EOF'
+  > let ignored = 0
   > EOF
 
   $ dune build --root producer @install
   $ dune install --root producer --prefix "$PWD/prefix"
+  $ test -e "$PWD/prefix/lib/repro/vlib/melange/vlib__Shared.cmt"
+  $ test -e "$PWD/prefix/lib/repro/vlib/melange/.private/vlib__Helper.cmt"
+  $ test -e "$PWD/prefix/lib/repro/vlib/melange/.private/vlib__Leaf.cmt"
 
   $ cat > consumer/dune-project <<'EOF'
   > (lang dune 3.24)
@@ -43,17 +59,49 @@ The virtual library and its implementation are both Melange-only.
   $ cat > consumer/impl/virt.ml <<'EOF'
   > let run () = Shared.answer
   > EOF
+  $ cat > consumer/impl/other.ml <<'EOF'
+  > let run () = 1
+  > EOF
   $ cat > consumer/dune <<'EOF'
   > (melange.emit
   >  (target output)
   >  (emit_stdlib false)
+  >  (compile_flags :standard --mel-cross-module-opt)
   >  (libraries impl))
   > EOF
 
   $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
-  > dune build --root consumer @melange
+  > dune build --root consumer --sandbox=symlink @melange
   Entering directory 'consumer'
   File "impl/.impl.objs/melange/_unknown_", line 1, characters 0-0:
   Error: No rule found for impl/.impl.objs/native/vlib__Shared.cmx
   Leaving directory 'consumer'
   [1]
+
+With annotations, dependency analysis should read the precise imports from the
+CMT, including private modules but excluding unused ones.
+
+  $ OCAMLPATH="$PWD/prefix/lib:$OCAMLPATH" \
+  > dune rules --root consumer --recursive --format=json --deps --display=quiet \
+  > impl/.impl.objs/melange/vlib__Virt.cmj > deps.json
+  Entering directory 'consumer'
+  Error: No rule found for impl/.impl.objs/native/vlib__Shared.cmx
+  -> required by transitive deps of vlib__Shared.impl in _build/default/impl
+  -> required by transitive deps of vlib__Virt.impl in _build/default/impl
+  Leaving directory 'consumer'
+  [1]
+  $ jq_dune -r '
+  >   [.[] | depsFilePaths
+  >    | select(endswith("vlib__Helper.cmi")
+  >             or endswith("vlib__Helper.cmj")
+  >             or endswith("vlib__Leaf.cmi")
+  >             or endswith("vlib__Leaf.cmj")
+  >             or endswith("vlib__Other.cmi")
+  >             or endswith("vlib__Other.cmj")
+  >             or endswith("vlib__Unused.cmi")
+  >             or endswith("vlib__Unused.cmj")
+  >             or endswith("vlib__Virt.cmi")
+  >             or endswith("vlib__Virt.cmj"))
+  >    | select(startswith("_build/default/impl/.impl.objs/melange/"))]
+  >   | unique[]
+  > ' deps.json


### PR DESCRIPTION
Add a separate cram test for installed Melange virtual libraries built without binary annotations, including private modules and a reverse virtual-module dependency.

Stacked on #78.