### PR TITLE
perf(stdune): avoid allocation in Nonempty_list.last

### DIFF
--- a/otherlibs/stdune/src/nonempty_list.ml
+++ b/otherlibs/stdune/src/nonempty_list.ml
@@ -2,9 +2,12 @@ type 'a t = ( :: ) of 'a * 'a list
 
 let hd (x :: _) = x
 
-let last = function
-  | [ t ] -> t
-  | _ :: ts -> List.last ts |> Option.value_exn
+let last =
+  let rec loop last = function
+    | [] -> last
+    | t :: ts -> loop t ts
+  in
+  fun (t :: ts) -> loop t ts
 ;;
 
 let destruct_last =


### PR DESCRIPTION
Return the final element of a non-empty list directly instead of allocating an intermediate option.

A local benchmark removes two minor-heap words per call for lists longer than one element. The benchmark harness is not included.