### PR TITLE
feat(melange): describe JavaScript outputs

### DIFF
--- a/bin/describe/describe.ml
+++ b/bin/describe/describe.ml
@@ -23,6 +23,7 @@ let subcommands =
   ; Describe_depexts.command
   ; Describe_location.command
   ; Describe_tests.command
+  ; Describe_melange_outputs.command
   ]
 ;;
 

--- a/bin/describe/describe_melange_outputs.ml
+++ b/bin/describe/describe_melange_outputs.ml
@@ -1,0 +1,61 @@
+open Import
+open Dune_rules
+module Js_output = Melange_rules.Js_output
+
+let output_to_dyn { Js_output.module_system; build_path; promoted_path } =
+  Dyn.record
+    [ "module_system", Dyn.string (Melange.Module_system.to_string module_system)
+    ; "build_path", Dyn.string (Path.Build.to_string build_path)
+    ; ( "promoted_path"
+      , Dyn.option (fun path -> Dyn.string (Path.Source.to_string path)) promoted_path )
+    ]
+;;
+
+let source_path file =
+  let path = Path.of_filename_relative_to_initial_cwd file in
+  let workspace_root = Path.to_absolute_filename Path.root |> Path.of_string in
+  match Path.drop_prefix path ~prefix:workspace_root with
+  | Some path -> Path.Source.of_local path
+  | None ->
+    User_error.raise
+      [ Pp.textf
+          "%s is not a source file in the workspace"
+          (Path.to_string_maybe_quoted path)
+      ]
+;;
+
+let term =
+  let+ builder = Common.Builder.term
+  and+ context_name = Common.context_arg ~doc:(Some "Build context to use.")
+  and+ format = Describe_format.arg
+  and+ file =
+    Arg.(
+      required
+      & pos
+          0
+          (some string)
+          None
+          (info [] ~docv:"FILE" ~doc:(Some "OCaml source file to look up.")))
+  in
+  let common, config = Common.init builder in
+  Scheduler_setup.go_with_rpc_server ~common ~config
+  @@ fun () ->
+  Build.build_memo_exn
+  @@ fun () ->
+  let open Memo.O in
+  let source = source_path file in
+  let* setup = Util.setup () in
+  let sctx = Dune_rules.Main.find_scontext_exn setup ~name:context_name in
+  let* outputs = Melange_rules.js_outputs_of_source ~sctx ~source in
+  List.map outputs ~f:output_to_dyn |> Dyn.list Fun.id |> Describe_format.print_dyn format;
+  Memo.return ()
+;;
+
+let command =
+  let doc =
+    "Print the JavaScript outputs generated for an OCaml source by enabled melange.emit \
+     stanzas. The output format of this command is experimental and is subject to change \
+     without warning"
+  in
+  Cmd.v (Cmd.info ~doc "melange-outputs") term
+;;

--- a/bin/describe/describe_melange_outputs.mli
+++ b/bin/describe/describe_melange_outputs.mli
@@ -1,0 +1,4 @@
+open Import
+
+(** Dune command to describe the Melange outputs for an OCaml source file. *)
+val command : unit Cmd.t

--- a/doc/changes/added/84.md
+++ b/doc/changes/added/84.md
@@ -1,0 +1,2 @@
+- Add `dune describe melange-outputs` to list all JavaScript build and
+  promoted outputs for an OCaml source (#84, @anmonteiro)

--- a/src/dune_rules/dune_rules.ml
+++ b/src/dune_rules/dune_rules.ml
@@ -54,6 +54,7 @@ module Private_context = Private_context
 module Odoc = Odoc
 module Library = Library
 module Melange = Melange
+module Melange_rules = Melange_rules
 module Executables = Executables
 module Tests = Tests
 module Stanzas = Stanzas

--- a/src/dune_rules/melange/melange_rules.ml
+++ b/src/dune_rules/melange/melange_rules.ml
@@ -44,6 +44,14 @@ module Output_kind = struct
   ;;
 end
 
+module Js_output = struct
+  type t =
+    { module_system : Melange.Module_system.t
+    ; build_path : Path.Build.t
+    ; promoted_path : Path.Source.t option
+    }
+end
+
 let setup_melange_sources_copy_rules ~sctx ~dir ~preprocess modules =
   let mods = Modules.fold_user_written modules ~init:[] ~f:List.cons in
   let context = Super_context.context sctx in
@@ -351,13 +359,10 @@ let js_targets_of_modules modules ~module_systems ~output =
       else acc)
 ;;
 
-let js_targets_of_libs ~sctx ~scope ~module_systems ~target_dir libs =
+let impl_modules_of_libs ~sctx ~scope libs =
   let of_lib lib =
     let+ _, modules = impl_only_modules_defined_in_this_lib ~sctx ~scope lib in
-    let output = output_of_lib ~target_dir lib in
-    List.concat_map modules ~f:(fun m ->
-      js_outputs_of_module ~module_systems ~output m
-      |> List.map ~f:(fun (_, target) -> Path.build target))
+    List.map modules ~f:(fun m -> lib, m)
   in
   Resolve.Memo.List.concat_map libs ~f:(fun lib ->
     let* base = of_lib lib in
@@ -368,6 +373,16 @@ let js_targets_of_libs ~sctx ~scope ~module_systems ~target_dir libs =
       let* vlib = vlib in
       let+ for_vlib = Resolve.Memo.lift_memo (of_lib vlib) in
       List.rev_append for_vlib base)
+;;
+
+let js_targets_of_libs ~sctx ~scope ~module_systems ~target_dir libs =
+  impl_modules_of_libs ~sctx ~scope libs
+  |> Resolve.Memo.map
+       ~f:
+         (List.concat_map ~f:(fun (lib, m) ->
+            let output = output_of_lib ~target_dir lib in
+            js_outputs_of_module ~module_systems ~output m
+            |> List.map ~f:(fun (_, target) -> Path.build target)))
 ;;
 
 let compute_promote_in_source ~promote_in_source ~project ~dir ~mode ~output ~src ~dst =
@@ -414,6 +429,29 @@ let compute_promote_in_source ~promote_in_source ~project ~dir ~mode ~output ~sr
          Some { Rule.Promote.Into.loc; dir = new_into_dir }
        in
        Promote { p with into })
+;;
+
+let promoted_path mode build_path =
+  match mode with
+  | Rule.Mode.Standard | Fallback | Ignore_source_files -> None
+  | Promote { only; into; _ } ->
+    let selected =
+      match only with
+      | None -> true
+      | Some predicate -> Predicate.test predicate (Path.Build.basename build_path)
+    in
+    if not selected
+    then None
+    else
+      Some
+        (match into with
+         | None -> Path.Build.drop_build_context_exn build_path
+         | Some { loc; dir } ->
+           let root =
+             Path.Build.parent_exn build_path |> Path.Build.drop_build_context_exn
+           in
+           let dir = Path.Source.relative root dir ~error_loc:loc in
+           Path.Source.relative_fname dir (Path.Build.basename build_path))
 ;;
 
 let build_js
@@ -747,6 +785,148 @@ let modules_for_js_and_obj_dir ~sctx ~dir_contents ~scope (mel : Melange_stanzas
 
 let should_promote_in_source scope = Melange.Cli.promotes_in_source (Scope.project scope)
 
+let expand_emit_rule_mode ~expander ~dir ~promote_in_source (mel : Melange_stanzas.Emit.t)
+  =
+  let mode =
+    match mel.promote with
+    | None -> Rule_mode.Standard
+    | Some promote -> Promote promote
+  in
+  match promote_in_source with
+  | true -> Rule_mode_expand.expand_path ~expander ~dir mode
+  | false -> Rule_mode_expand.expand_str ~expander mode
+;;
+
+let module_source_path module_ =
+  match Module.source module_ ~ml_kind:Impl with
+  | None -> None
+  | Some file ->
+    let path = Module.File.original_path file in
+    (match Path.as_in_source_tree path with
+     | Some path -> Some path
+     | None ->
+       Path.as_in_build_dir path |> Option.map ~f:Path.Build.drop_build_context_exn)
+;;
+
+let js_outputs_of_module_source
+      ~source
+      ~module_systems
+      ~output
+      ~promote_in_source
+      ~project
+      ~dir
+      ~mode
+      module_
+  =
+  match module_source_path module_ with
+  | None -> []
+  | Some module_source when not (Path.Source.equal source module_source) -> []
+  | Some _ ->
+    let src = Module.source_without_pp module_ ~ml_kind:Impl |> Option.value_exn in
+    js_outputs_of_module ~module_systems ~output module_
+    |> List.map ~f:(fun (module_system, build_path) ->
+      let mode =
+        compute_promote_in_source
+          ~promote_in_source
+          ~project
+          ~dir
+          ~mode
+          ~output
+          ~src
+          ~dst:build_path
+      in
+      { Js_output.module_system
+      ; build_path
+      ; promoted_path = promoted_path mode build_path
+      })
+;;
+
+let js_outputs_of_emit
+      ~sctx
+      ~source
+      ~dir
+      ~dir_contents
+      ~scope
+      ~promote_in_source
+      ~mode
+      (mel : Melange_stanzas.Emit.t)
+  =
+  let target_dir = Melange_stanzas.Emit.target_dir ~dir mel in
+  let* compile_info = compile_info ~scope mel in
+  let* requires_link =
+    Lib.Compile.requires_link compile_info ~for_
+    |> Memo.Lazy.force
+    |> Resolve.Memo.read_memo
+  in
+  let* _, modules_for_js, _ = modules_for_js_and_obj_dir ~sctx ~dir_contents ~scope mel
+  and* library_modules =
+    impl_modules_of_libs ~sctx ~scope requires_link |> Resolve.Memo.read_memo
+  in
+  let project = Scope.project scope in
+  let outputs module_systems output modules =
+    List.concat_map modules ~f:(fun module_ ->
+      js_outputs_of_module_source
+        ~source
+        ~module_systems
+        ~output
+        ~promote_in_source
+        ~project
+        ~dir
+        ~mode
+        module_)
+  in
+  let entries =
+    outputs
+      mel.module_systems
+      (Output_kind.Private_library_or_emit target_dir)
+      modules_for_js
+  in
+  let libraries =
+    List.concat_map library_modules ~f:(fun (lib, module_) ->
+      outputs mel.module_systems (output_of_lib ~target_dir lib) [ module_ ])
+  in
+  Memo.return (List.rev_append entries libraries)
+;;
+
+let js_outputs_of_source ~sctx ~source =
+  let context = Super_context.context sctx in
+  let context_name = Context.name context in
+  let* dune_files = Dune_load.dune_files context_name in
+  let+ outputs =
+    Memo.parallel_map dune_files ~f:(fun dune_file ->
+      Dune_file.find_stanzas dune_file Melange_stanzas.Emit.key
+      >>= function
+      | [] -> Memo.return []
+      | stanzas ->
+        let dir =
+          Path.Build.append_source (Context.build_dir context) (Dune_file.dir dune_file)
+        in
+        let* expander = Super_context.expander sctx ~dir in
+        Memo.parallel_map stanzas ~f:(fun (mel : Melange_stanzas.Emit.t) ->
+          let* enabled = Expander.eval_blang expander mel.enabled_if in
+          if not enabled
+          then Memo.return []
+          else
+            let* dir_contents = Dir_contents.get sctx ~dir
+            and* scope = Scope.DB.find_by_dir dir in
+            let promote_in_source = should_promote_in_source scope in
+            let* mode = expand_emit_rule_mode ~expander ~dir ~promote_in_source mel in
+            js_outputs_of_emit
+              ~sctx
+              ~source
+              ~dir
+              ~dir_contents
+              ~scope
+              ~promote_in_source
+              ~mode
+              mel)
+        >>| List.concat)
+  in
+  List.concat outputs
+  |> List.sort_uniq ~compare:(fun a b ->
+    Path.Build.compare a.Js_output.build_path b.Js_output.build_path)
+;;
+
 let setup_entries_js
       ~sctx
       ~dir
@@ -1006,14 +1186,7 @@ let setup_emit_js_rules ~dir_contents ~dir ~scope ~sctx mel =
   let promote_in_source = should_promote_in_source scope in
   let* mode =
     let* expander = Super_context.expander sctx ~dir in
-    let mode =
-      match mel.promote with
-      | None -> Rule_mode.Standard
-      | Some p -> Promote p
-    in
-    match promote_in_source with
-    | true -> Rule_mode_expand.expand_path ~expander ~dir mode
-    | false -> Rule_mode_expand.expand_str ~expander mode
+    expand_emit_rule_mode ~expander ~dir ~promote_in_source mel
   in
   let* compile_info = compile_info ~scope mel in
   let* requires_link_resolve =

--- a/src/dune_rules/melange/melange_rules.mli
+++ b/src/dune_rules/melange/melange_rules.mli
@@ -1,5 +1,18 @@
 open Import
 
+module Js_output : sig
+  type t =
+    { module_system : Melange.Module_system.t
+    ; build_path : Path.Build.t
+    ; promoted_path : Path.Source.t option
+    }
+end
+
+val js_outputs_of_source
+  :  sctx:Super_context.t
+  -> source:Path.Source.t
+  -> Js_output.t list Memo.t
+
 val setup_melange_sources_copy_rules
   :  sctx:Super_context.t
   -> dir:Path.Build.t

--- a/test/blackbox-tests/test-cases/melange/two-emit-stanzas.t
+++ b/test/blackbox-tests/test-cases/melange/two-emit-stanzas.t
@@ -74,7 +74,26 @@ module systems and promotion destination.
   >  (enabled_if false))
   > EOF
 
-The command does not exist yet.
+The command reports every output, including promoted paths, and ignores disabled
+stanzas.
 
-  $ dune describe melange-outputs lib/shared.ml >/dev/null 2>&1
-  [1]
+  $ dune describe melange-outputs lib/shared.ml
+  (((module_system commonjs)
+    (build_path _build/default/dist-one/lib/shared.js)
+    (promoted_path (promoted-one/lib/shared.js)))
+   ((module_system commonjs)
+    (build_path _build/default/dist-two/lib/shared.cjs)
+    (promoted_path (promoted-two/lib/shared.cjs)))
+   ((module_system es6)
+    (build_path _build/default/dist-two/lib/shared.mjs)
+    (promoted_path (promoted-two/lib/shared.mjs)))
+   ((module_system commonjs)
+    (build_path _build/default/dist-unpromoted/lib/shared.js)
+    (promoted_path ())))
+
+Entry modules are included too.
+
+  $ dune describe melange-outputs entry.ml
+  (((module_system commonjs)
+    (build_path _build/default/dist-one/entry.js)
+    (promoted_path (promoted-one/entry.js))))

--- a/test/blackbox-tests/test-cases/melange/two-emit-stanzas.t
+++ b/test/blackbox-tests/test-cases/melange/two-emit-stanzas.t
@@ -23,3 +23,58 @@ Building a project with 2 melange.emit stanzas should add rules to both aliases
 
   $ dune build @mel
   $ dune build @second
+
+A library source can be emitted by several enabled stanzas, each with its own
+module systems and promotion destination.
+
+  $ make_melange_project 3.25 1.0
+  $ mkdir lib
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (name shared)
+  >  (wrapped false)
+  >  (modes melange))
+  > EOF
+  $ cat > lib/shared.ml <<EOF
+  > let message = "shared"
+  > EOF
+  $ cat > entry.ml <<EOF
+  > let message = Shared.message
+  > EOF
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (target dist-one)
+  >  (modules entry)
+  >  (libraries shared)
+  >  (emit_stdlib false)
+  >  (promote (until-clean) (into promoted-one))
+  >  (module_systems
+  >   (commonjs js)))
+  > (melange.emit
+  >  (target dist-two)
+  >  (modules)
+  >  (libraries shared)
+  >  (emit_stdlib false)
+  >  (promote (until-clean) (into promoted-two))
+  >  (module_systems
+  >   (commonjs cjs)
+  >   (esm mjs)))
+  > (melange.emit
+  >  (target dist-unpromoted)
+  >  (modules)
+  >  (libraries shared)
+  >  (emit_stdlib false)
+  >  (module_systems
+  >   (commonjs js)))
+  > (melange.emit
+  >  (target ignored)
+  >  (modules)
+  >  (libraries shared)
+  >  (emit_stdlib false)
+  >  (enabled_if false))
+  > EOF
+
+The command does not exist yet.
+
+  $ dune describe melange-outputs lib/shared.ml >/dev/null 2>&1
+  [1]


### PR DESCRIPTION
Add `dune describe melange-outputs` to report every JavaScript build and promoted output for an OCaml source.

Relates to ocaml/dune#7459.