### PR TITLE
refactor(foreign): reuse expander project

### DIFF
--- a/src/dune_rules/foreign_rules.ml
+++ b/src/dune_rules/foreign_rules.ml
@@ -225,11 +225,10 @@ let base_flags ~(kind : Foreign_language.t) ~use_standard_flags ~ctx ~ocaml_conf
          ])
 ;;
 
-let compilation_flags ~sctx ~dir ~expander ~loc ~(src : Foreign.Source.t) =
+let compilation_flags ~sctx ~project ~dir ~expander ~loc ~(src : Foreign.Source.t) =
   let open Action_builder.O in
   let kind = Foreign.Source.language src in
   let ctx = Super_context.context sctx in
-  let* project = Action_builder.of_memo (Dune_load.find_project ~dir) in
   let* ocaml = Action_builder.of_memo (Context.ocaml ctx) in
   let+ user_flags =
     match Foreign.Source.kind src with
@@ -258,11 +257,11 @@ let compilation_flags ~sctx ~dir ~expander ~loc ~(src : Foreign.Source.t) =
   @ user_flags
 ;;
 
-let c_compile_args ~sctx ~dir ~expander ~loc ~src ~include_flags =
+let c_compile_args ~sctx ~project ~dir ~expander ~loc ~src ~include_flags =
   Command.Args.S
     [ Dyn
         (Action_builder.map
-           (compilation_flags ~sctx ~dir ~expander ~loc ~src)
+           (compilation_flags ~sctx ~project ~dir ~expander ~loc ~src)
            ~f:(fun flags -> Command.Args.As flags))
     ; Dyn
         (let open Action_builder.O in
@@ -287,6 +286,7 @@ let build_c ~sctx ~dir ~expander ~include_flags (loc, (src : Foreign.Source.t), 
     | Ctypes _ -> Action_builder.return Env.empty, Sandbox_config.default
   in
   let ctx = Super_context.context sctx in
+  let project = Expander.project expander in
   let* ocaml = Context.ocaml ctx in
   (* Emit warning for Stubs case when standard flags are overridden *)
   let* () =
@@ -299,7 +299,6 @@ let build_c ~sctx ~dir ~expander ~include_flags (loc, (src : Foreign.Source.t), 
          [dune-project] file (thus defaulting to [true]), the [:standard] set of
          flags has been overridden and we are not in a vendored project *)
       let has_standard = Ordered_set_lang.Unexpanded.has_standard flags in
-      let* project = Dune_load.find_project ~dir in
       let use_standard_flags = Dune_project.use_standard_c_and_cxx_flags project in
       let+ is_vendored =
         match Path.Build.drop_build_context dir with
@@ -356,7 +355,7 @@ let build_c ~sctx ~dir ~expander ~include_flags (loc, (src : Foreign.Source.t), 
             errors happen only when compiling c files.) *)
        ~sandbox:Sandbox_config.no_sandboxing
        c_compiler
-       [ c_compile_args ~sctx ~dir ~expander ~loc ~src ~include_flags
+       [ c_compile_args ~sctx ~project ~dir ~expander ~loc ~src ~include_flags
        ; Hidden_deps (Dep.Set.singleton (Dep.file_selector caml_headers))
        ; S output_param
        ; A "-c"

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -21,10 +21,10 @@ let cclibs =
          c_library_flags)
 ;;
 
-let expand_c_library_flags sctx expander ~dir ~has_cxx flags =
+let expand_c_library_flags sctx expander ~has_cxx flags =
   let standard =
     let open Action_builder.O in
-    let* project = Action_builder.of_memo (Dune_load.find_project ~dir) in
+    let* project = Action_builder.return (Expander.project expander) in
     match Dune_project.use_standard_c_and_cxx_flags project with
     | Some true when has_cxx () ->
       let ctx = Super_context.context sctx in
@@ -85,7 +85,6 @@ let build_lib
          expand_c_library_flags
            sctx
            expander
-           ~dir
            ~has_cxx:(fun () -> Buildable.has_foreign_cxx lib.buildable)
            lib.c_library_flags
          >>| map_cclibs)
@@ -271,7 +270,6 @@ let foreign_rules (library : Foreign_library.t) ~sctx ~expander ~dir ~dir_conten
     expand_c_library_flags
       sctx
       expander
-      ~dir
       ~has_cxx:(fun () -> Foreign.Sources.has_cxx_sources foreign_sources)
       library.c_library_flags
   in
@@ -327,7 +325,6 @@ let build_stubs lib ~cctx ~dir ~expander ~requires ~dir_contents ~vlib_stubs_o_f
           expand_c_library_flags
             sctx
             expander
-            ~dir
             ~has_cxx:(fun () -> Foreign.Sources.has_cxx_sources foreign_sources)
             lib.c_library_flags
         and+ ctypes_lib =


### PR DESCRIPTION
Reuse already-resolved expander projects while evaluating foreign compilation and C library flags.