### PR TITLE
refactor(foreign): reuse ocamlmklib context

### DIFF
--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -177,7 +177,6 @@ let ocamlmklib
         ~f:(cclibs ocaml.lib_config.ccomp_type ~flag:"-ldopt")
     in
     fun ~custom ~sandbox targets ->
-      let ctx = Super_context.context sctx in
       [ Command.Args.A "-g"
       ; (if custom then A "-custom" else Command.Args.empty)
       ; A "-o"


### PR DESCRIPTION
Reuse the context already resolved for ocamlmklib toolchain and rule generation.