### PR TITLE
fix(melange): reject empty module systems

### DIFF
--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -56,7 +56,7 @@ module Emit = struct
             ]
       in
       let+ module_systems =
-        repeat
+        repeat1
           (pair module_system extension_field
            <|> let+ loc, module_system = located module_system in
                let _, ext = Module_system.default in

--- a/test/blackbox-tests/test-cases/melange/module-systems.t
+++ b/test/blackbox-tests/test-cases/melange/module-systems.t
@@ -83,7 +83,7 @@ Defaults to commonjs / `.js` if no config present at all
   $ ls _build/default/output
   main.js
 
-An explicitly empty module systems field is currently accepted
+Rejects an explicitly empty module systems field
 
   $ dune clean
   $ cat > dune <<EOF
@@ -95,6 +95,11 @@ An explicitly empty module systems field is currently accepted
   > EOF
 
   $ dune build @mel
+  File "dune", line 5, characters 1-17:
+  5 |  (module_systems))
+       ^^^^^^^^^^^^^^^^
+  Error: Not enough arguments for "module_systems"
+  [1]
 
 Errors out if extension starts with dot
 

--- a/test/blackbox-tests/test-cases/melange/module-systems.t
+++ b/test/blackbox-tests/test-cases/melange/module-systems.t
@@ -83,6 +83,19 @@ Defaults to commonjs / `.js` if no config present at all
   $ ls _build/default/output
   main.js
 
+An explicitly empty module systems field is currently accepted
+
+  $ dune clean
+  $ cat > dune <<EOF
+  > (melange.emit
+  >  (alias mel)
+  >  (target output)
+  >  (emit_stdlib false)
+  >  (module_systems))
+  > EOF
+
+  $ dune build @mel
+
 Errors out if extension starts with dot
 
   $ cat > dune <<EOF


### PR DESCRIPTION
Reject explicitly empty module_systems fields and cover the behavior with a cram test.