### PR TITLE
fix(inline-tests): reject empty mode lists

### DIFF
--- a/src/dune_rules/inline_tests_info.ml
+++ b/src/dune_rules/inline_tests_info.ml
@@ -137,7 +137,14 @@ module Mode_conf = struct
   module Set = struct
     include O.Set
 
-    let decode = repeat decode >>| of_list
+    let decode =
+      let+ loc = loc
+      and+ modes = repeat decode in
+      match modes with
+      | [] -> User_error.raise ~loc [ Pp.text "No inline test mode defined" ]
+      | _ :: _ -> of_list modes
+    ;;
+
     let default = of_list [ Best ]
   end
 end

--- a/test/blackbox-tests/test-cases/inline-tests/inline_tests-multi-mode.t
+++ b/test/blackbox-tests/test-cases/inline-tests/inline_tests-multi-mode.t
@@ -29,3 +29,20 @@ Reproduction case for #3347
   $ dune runtest
   Test byte
   Test native
+
+An explicitly empty mode list is rejected rather than silently disabling the
+tests.
+
+  $ cat >dune <<EOF
+  > (library
+  >  (name test)
+  >  (modules test)
+  >  (inline_tests (modes)))
+  > EOF
+
+  $ dune runtest
+  File "dune", line 4, characters 15-22:
+  4 |  (inline_tests (modes)))
+                     ^^^^^^^
+  Error: No inline test mode defined
+  [1]


### PR DESCRIPTION
Reject explicitly empty inline-test mode lists.