### PR TITLE
fix(library): reject empty mode lists

### DIFF
--- a/src/dune_lang/stanzas/mode_conf.ml
+++ b/src/dune_lang/stanzas/mode_conf.ml
@@ -206,8 +206,19 @@ module Lib = struct
       set_of_list ~empty ~update:Map.update input
     ;;
 
+    let validate_nonempty ~loc (t : t) =
+      if
+        Option.is_none t.melange
+        && Option.is_none t.ocaml.byte
+        && Option.is_none t.ocaml.native
+        && Option.is_none t.ocaml.best
+      then User_error.raise ~loc [ Pp.text "No library mode defined" ];
+      t
+    ;;
+
     let decode_osl ~stanza_loc project =
-      let+ modes = Ordered_set_lang.decode in
+      let+ loc = loc
+      and+ modes = Ordered_set_lang.decode in
       let standard =
         Set.default stanza_loc |> Set.to_list |> List.map ~f:(fun (m, k) -> Ocaml m, k)
       in
@@ -224,9 +235,15 @@ module Lib = struct
           in
           mode, Kind.Requested loc)
       |> of_list
+      |> validate_nonempty ~loc
     ;;
 
-    let decode = decode_set decode ~of_list
+    let decode =
+      let+ loc = loc
+      and+ modes = decode_set decode ~of_list in
+      validate_nonempty ~loc modes
+    ;;
+
     let default loc : t = { empty with ocaml = Set.default loc }
 
     let eval t ~has_native =

--- a/test/blackbox-tests/test-cases/lib-modes.t
+++ b/test/blackbox-tests/test-cases/lib-modes.t
@@ -43,3 +43,33 @@ in a version of dune lang that does not support them
 Works for the most recent version
 
   $ dune build hello.exe
+
+An explicitly empty mode list is rejected.
+
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (modes)
+  >  (name mylib))
+  > EOF
+
+  $ dune build
+  File "lib/dune", line 2, characters 1-8:
+  2 |  (modes)
+       ^^^^^^^
+  Error: No library mode defined
+  [1]
+
+The ordered set language cannot be used to remove every mode either.
+
+  $ cat > lib/dune <<EOF
+  > (library
+  >  (modes :standard \ byte best)
+  >  (name mylib))
+  > EOF
+
+  $ dune build
+  File "lib/dune", line 2, characters 1-30:
+  2 |  (modes :standard \ byte best)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: No library mode defined
+  [1]


### PR DESCRIPTION
Reject library mode fields that evaluate to no modes.