### PR TITLE
fix(install): reject empty install stanzas

### DIFF
--- a/src/dune_rules/stanzas/install_conf.ml
+++ b/src/dune_rules/stanzas/install_conf.ml
@@ -48,6 +48,11 @@ let decode =
          , Option.value dirs ~default:[]
          , Option.value source_trees ~default:[] )
      in
+     if List.is_empty files && List.is_empty dirs && List.is_empty source_trees
+     then
+       User_error.raise
+         ~loc
+         [ Pp.text "At least one of dirs, files, or source_trees must be non-empty" ];
      (match section with
       | loc, Section Misc ->
         User_error.raise

--- a/test/blackbox-tests/test-cases/stanzas/install/install-empty.t
+++ b/test/blackbox-tests/test-cases/stanzas/install/install-empty.t
@@ -1,0 +1,24 @@
+An install stanza must contain at least one entry.
+
+  $ make_dune_project 3.11
+  $ touch foo.opam
+
+  $ cat >dune <<EOF
+  > (install
+  >  (section share)
+  >  (files)
+  >  (dirs)
+  >  (source_trees)
+  >  (package foo))
+  > EOF
+
+  $ dune build
+  File "dune", lines 1-6, characters 0-74:
+  1 | (install
+  2 |  (section share)
+  3 |  (files)
+  4 |  (dirs)
+  5 |  (source_trees)
+  6 |  (package foo))
+  Error: At least one of dirs, files, or source_trees must be non-empty
+  [1]


### PR DESCRIPTION
Require install stanzas to contain at least one file, directory, or source tree.