### PR TITLE
fix(rocq): validate extraction output files

### DIFF
--- a/src/dune_rules/rocq/rocq_stanza.ml
+++ b/src/dune_rules/rocq/rocq_stanza.ml
@@ -97,6 +97,21 @@ module Extraction = struct
 
   let target_fnames t = t.target_fnames
 
+  let filenames field =
+    let filename =
+      let+ loc, filename = located string in
+      match Filename.of_string filename with
+      | Some _ -> filename
+      | None ->
+        User_error.raise ~loc [ Pp.textf "Entries in field %S must be filenames" field ]
+    in
+    let+ loc = loc
+    and+ filenames = repeat filename in
+    match filenames with
+    | [] -> User_error.raise ~loc [ Pp.textf "Field %S must not be empty" field ]
+    | _ :: _ -> filenames
+  ;;
+
   let decode =
     fields
       (let* ver = get_rocq_syntax () in
@@ -109,11 +124,11 @@ module Extraction = struct
               ~extra_info:
                 "Use (extracted_files ...) instead, listing each .ml and .mli file \
                  explicitly."
-            >>> repeat string)
+            >>> filenames "extracted_modules")
        and+ extracted_files_opt =
          field_o
            "extracted_files"
-           (Dune_lang.Syntax.since rocq_syntax (0, 13) >>> repeat string)
+           (Dune_lang.Syntax.since rocq_syntax (0, 13) >>> filenames "extracted_files")
        and+ prelude = field "prelude" (located (string >>| Rocq_module.Name.make))
        and+ buildable = Buildable.decode
        and+ loc = loc in

--- a/test/blackbox-tests/test-cases/stanzas/rocq-extraction-validation.t
+++ b/test/blackbox-tests/test-cases/stanzas/rocq-extraction-validation.t
@@ -1,0 +1,45 @@
+Extraction outputs must be nonempty filenames.
+
+  $ make_rocq_project 3.23 0.13
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extr)
+  >  (extracted_files))
+  > EOF
+
+  $ dune build
+  File "dune", line 3, characters 1-18:
+  3 |  (extracted_files))
+       ^^^^^^^^^^^^^^^^^
+  Error: Field "extracted_files" must not be empty
+  [1]
+
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extr)
+  >  (extracted_files ../extr.ml))
+  > EOF
+
+  $ dune build
+  File "dune", line 3, characters 18-28:
+  3 |  (extracted_files ../extr.ml))
+                        ^^^^^^^^^^
+  Error: Entries in field "extracted_files" must be filenames
+  [1]
+
+The legacy extracted_modules field must also be nonempty.
+
+  $ make_rocq_project 3.22 0.12
+  $ cat >dune <<EOF
+  > (rocq.extraction
+  >  (prelude extr)
+  >  (extracted_modules))
+  > EOF
+
+  $ dune build
+  File "dune", line 3, characters 1-20:
+  3 |  (extracted_modules))
+       ^^^^^^^^^^^^^^^^^^^
+  Error: Field "extracted_modules" must not be empty
+  [1]


### PR DESCRIPTION
Require Rocq extraction outputs to be nonempty filename lists.