### PR TITLE
fix(melange): validate emit target names

### DIFF
--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -96,20 +96,18 @@ module Emit = struct
       (let* loc = loc in
        let+ target =
          let of_string ~loc s =
-           match String.is_empty s with
-           | true ->
+           match Filename.of_string s with
+           | Some _ -> s
+           | None when String.is_empty s ->
              User_error.raise ~loc [ Pp.textf "The field target can not be empty" ]
-           | false ->
-             (match Filename.dirname s with
-              | "." -> s
-              | _ ->
-                User_error.raise
-                  ~loc
-                  [ Pp.textf
-                      "The field target must use simple names and can not include paths \
-                       to other folders. To emit JavaScript files in another folder, \
-                       move the `melange.emit` stanza to that folder"
-                  ])
+           | None ->
+             User_error.raise
+               ~loc
+               [ Pp.textf
+                   "The field target must use simple names and can not include paths to \
+                    other folders. To emit JavaScript files in another folder, move the \
+                    `melange.emit` stanza to that folder"
+               ]
          in
          field "target" (plain_string (fun ~loc s -> of_string ~loc s))
        and+ alias = field_o "alias" Dune_lang.Alias.decode

--- a/test/blackbox-tests/test-cases/melange/target-validation.t
+++ b/test/blackbox-tests/test-cases/melange/target-validation.t
@@ -23,6 +23,46 @@ Target should not be empty
   Error: The field target can not be empty
   [1]
 
+Target should not use a special directory name
+
+  $ cat > dune <<EOF
+  > (library
+  >  (name $lib)
+  >  (modes melange))
+  > (melange.emit
+  >  (target .)
+  >  (emit_stdlib false)
+  >  (libraries $lib))
+  > EOF
+
+  $ dune build
+  File "dune", line 5, characters 9-10:
+  5 |  (target .)
+               ^
+  Error: The field target must use simple names and can not include paths to
+  other folders. To emit JavaScript files in another folder, move the
+  `melange.emit` stanza to that folder
+  [1]
+
+  $ cat > dune <<EOF
+  > (library
+  >  (name $lib)
+  >  (modes melange))
+  > (melange.emit
+  >  (target ..)
+  >  (emit_stdlib false)
+  >  (libraries $lib))
+  > EOF
+
+  $ dune build
+  File "dune", line 5, characters 9-11:
+  5 |  (target ..)
+               ^^
+  Error: The field target must use simple names and can not include paths to
+  other folders. To emit JavaScript files in another folder, move the
+  `melange.emit` stanza to that folder
+  [1]
+
 Target should not try to descend into subdirectories
 
   $ cat > dune <<EOF


### PR DESCRIPTION
Reject special directory names as melange.emit targets.