### PR TITLE
fix(site): reject plugins without libraries

### DIFF
--- a/src/dune_rules/sites/plugin.ml
+++ b/src/dune_rules/sites/plugin.ml
@@ -13,7 +13,14 @@ let decode =
   let* () = Dune_lang.Syntax.since Site.dune_site_syntax (0, 1) in
   fields
     (let+ name = field "name" Package.Name.decode
-     and+ libraries = field "libraries" (repeat (located Lib_name.decode))
+     and+ libraries =
+       field
+         "libraries"
+         (let+ loc = loc
+          and+ libraries = repeat (located Lib_name.decode) in
+          match libraries with
+          | [] -> User_error.raise ~loc [ Pp.text "No plugin library defined" ]
+          | _ :: _ -> libraries)
      and+ site = field "site" (located (pair Package.Name.decode Site.decode))
      and+ package = Stanza_pkg.field ~stanza:"plugin"
      and+ optional = field_b "optional" in

--- a/test/blackbox-tests/test-cases/dune-site/plugin-empty-libraries.t
+++ b/test/blackbox-tests/test-cases/dune-site/plugin-empty-libraries.t
@@ -1,0 +1,23 @@
+A plugin must load at least one library.
+
+  $ cat >dune-project <<EOF
+  > (lang dune 3.8)
+  > (using dune_site 0.1)
+  > (package
+  >  (name foo)
+  >  (sites (lib plugins)))
+  > EOF
+
+  $ cat >dune <<EOF
+  > (plugin
+  >  (name empty)
+  >  (libraries)
+  >  (site (foo plugins)))
+  > EOF
+
+  $ dune build
+  File "dune", line 3, characters 1-12:
+  3 |  (libraries)
+       ^^^^^^^^^^^
+  Error: No plugin library defined
+  [1]


### PR DESCRIPTION
Require plugin stanzas to name at least one library.