### PR TITLE
fix(menhir): validate merge target names

### DIFF
--- a/src/dune_rules/menhir/menhir_stanza.ml
+++ b/src/dune_rules/menhir/menhir_stanza.ml
@@ -18,7 +18,14 @@ type t =
 
 let decode =
   fields
-    (let+ merge_into = field_o "merge_into" string
+    (let+ merge_into =
+       field_o
+         "merge_into"
+         (let+ loc, merge_into = located string in
+          match Filename.of_string merge_into with
+          | Some _ -> merge_into
+          | None ->
+            User_error.raise ~loc [ Pp.text "merge_into must be a valid filename" ])
      and+ flags = Ordered_set_lang.Unexpanded.field "flags"
      and+ modules =
        Ordered_set_lang.Unexpanded.field

--- a/test/blackbox-tests/test-cases/menhir/merge-into-validation.t
+++ b/test/blackbox-tests/test-cases/menhir/merge-into-validation.t
@@ -1,0 +1,29 @@
+The merge_into field must name a file in the stanza directory.
+
+  $ make_menhir_project 3.21 3.0
+
+  $ cat >dune <<EOF
+  > (menhir
+  >  (merge_into ../parser)
+  >  (modules parser))
+  > EOF
+
+  $ dune build
+  File "dune", line 2, characters 13-22:
+  2 |  (merge_into ../parser)
+                   ^^^^^^^^^
+  Error: merge_into must be a valid filename
+  [1]
+
+  $ cat >dune <<EOF
+  > (menhir
+  >  (merge_into "")
+  >  (modules parser))
+  > EOF
+
+  $ dune build
+  File "dune", line 2, characters 13-15:
+  2 |  (merge_into "")
+                   ^^
+  Error: merge_into must be a valid filename
+  [1]


### PR DESCRIPTION
Require Menhir merge targets to be filenames in the stanza directory.