### PR TITLE
fix(toplevel): validate custom toplevel names

### DIFF
--- a/src/dune_rules/stanzas/toplevel_stanza.ml
+++ b/src/dune_rules/stanzas/toplevel_stanza.ml
@@ -18,7 +18,13 @@ let decode =
   let* () = Dune_lang.Syntax.since Stanza.syntax (1, 7) in
   fields
     (let+ loc = loc
-     and+ name = field "name" string
+     and+ name =
+       field
+         "name"
+         (let+ loc, name = located string in
+          match Filename.of_string name with
+          | Some _ -> name
+          | None -> User_error.raise ~loc [ Pp.text "name must be a valid filename" ])
      and+ libraries = field "libraries" (repeat (located Lib_name.decode)) ~default:[]
      and+ pps =
        field

--- a/test/blackbox-tests/test-cases/stanzas/toplevel-stanza/name-validation.t
+++ b/test/blackbox-tests/test-cases/stanzas/toplevel-stanza/name-validation.t
@@ -1,0 +1,27 @@
+A custom toplevel name must be a filename.
+
+  $ make_dune_project 3.21
+
+  $ cat >dune <<EOF
+  > (toplevel
+  >  (name ../foo))
+  > EOF
+
+  $ dune build
+  File "dune", line 2, characters 7-13:
+  2 |  (name ../foo))
+             ^^^^^^
+  Error: name must be a valid filename
+  [1]
+
+  $ cat >dune <<EOF
+  > (toplevel
+  >  (name ""))
+  > EOF
+
+  $ dune build
+  File "dune", line 2, characters 7-9:
+  2 |  (name ""))
+             ^^
+  Error: name must be a valid filename
+  [1]


### PR DESCRIPTION
Require custom toplevel names to be filenames in the stanza directory.