### PR TITLE
refactor(decoder): make repeat1 return a nonempty list

### DIFF
--- a/src/dune_lang/action.ml
+++ b/src/dune_lang/action.ml
@@ -336,10 +336,10 @@ let cstrs_dune_file t =
       Echo (x :: xs) )
   ; ( "cat"
     , let* xs = repeat1 sw in
-      (if List.length xs > 1
+      (if Nonempty_list.length xs > 1
        then Syntax.since ~what:"Passing several arguments to 'cat'" Stanza.syntax (3, 4)
        else return ())
-      >>> return (Cat xs) )
+      >>> return (Cat (Nonempty_list.to_list xs)) )
   ; ( "copy"
     , let+ src = sw
       and+ dst = sw in

--- a/src/dune_lang/dialect.ml
+++ b/src/dune_lang/dialect.ml
@@ -113,7 +113,8 @@ let decode =
     and+ merlin_reader =
       field_o
         "merlin_reader"
-        (Syntax.since Stanza.syntax (3, 16) >>> located (repeat1 string))
+        (Syntax.since Stanza.syntax (3, 16)
+         >>> located (repeat1 string >>| Nonempty_list.to_list))
     and+ syntax_ver = Syntax.get_exn Stanza.syntax in
     let ver = 3, 9 in
     if syntax_ver < ver && Option.is_some (String.index_from extension 1 '.')

--- a/src/dune_lang/package_info.ml
+++ b/src/dune_lang/package_info.ml
@@ -198,10 +198,10 @@ let decode ?since () =
       "license"
       (Syntax.since Stanza.syntax (v (1, 9))
        >>> let* l = repeat1 string in
-           (if List.length l > 1
+           (if Nonempty_list.length l > 1
             then Syntax.since ~what:"Parsing several licenses" Stanza.syntax (v (3, 2))
             else return ())
-           >>> return l)
+           >>> return (Nonempty_list.to_list l))
   and+ homepage = field_o "homepage" (Syntax.since Stanza.syntax (v (1, 10)) >>> string)
   and+ documentation =
     field_o "documentation" (Syntax.since Stanza.syntax (v (1, 10)) >>> string)

--- a/src/dune_rules/melange/melange_stanzas.ml
+++ b/src/dune_rules/melange/melange_stanzas.ml
@@ -64,8 +64,9 @@ module Emit = struct
       in
       let module_systems =
         match
-          Filename.Extension.Map.of_list_map module_systems ~f:(fun (ms, (loc, ext)) ->
-            ext, (loc, ms))
+          Filename.Extension.Map.of_list_map
+            (Nonempty_list.to_list module_systems)
+            ~f:(fun (ms, (loc, ext)) -> ext, (loc, ms))
         with
         | Ok m -> Filename.Extension.Map.to_list_map m ~f:(fun ext (_loc, ms) -> ms, ext)
         | Error (ext, (_, (loc1, _)), (_, (loc2, _))) ->

--- a/src/dune_rules/stanzas/executables.ml
+++ b/src/dune_rules/stanzas/executables.ml
@@ -23,7 +23,7 @@ module Names : sig
     -> Install_conf.t option
 end = struct
   type public =
-    { public_names : (Loc.t * string option) list
+    { public_names : (Loc.t * string option) Nonempty_list.t
     ; package : Package.t
     }
 
@@ -34,11 +34,7 @@ end = struct
     }
 
   let names t = t.names
-
-  let public_names t =
-    Option.map t.public ~f:(fun p -> Nonempty_list.of_list_exn p.public_names)
-  ;;
-
+  let public_names t = Option.map t.public ~f:(fun p -> p.public_names)
   let package t = Option.map t.public ~f:(fun p -> p.package)
   let has_public_name t = Option.is_some t.public
 
@@ -60,7 +56,7 @@ end = struct
       ~f:(fun (names, public_names) ->
         match names, public_names with
         | Some names, Some public_names ->
-          if List.length public_names = List.length names
+          if Nonempty_list.length public_names = Nonempty_list.length names
           then Ok (Some names, Some public_names)
           else
             Error
@@ -77,7 +73,8 @@ end = struct
     let dash_is_none = dune_syntax >= (3, 8) in
     let+ name = field_o "name" (located string)
     and+ public_name = field_o "public_name" (public_name ~dash_is_none) in
-    Option.map name ~f:List.singleton, Option.map public_name ~f:List.singleton
+    ( Option.map name ~f:(fun name -> Nonempty_list.[ name ])
+    , Option.map public_name ~f:(fun public_name -> Nonempty_list.[ public_name ]) )
   ;;
 
   let pluralize s ~multi = if multi then s ^ "s" else s
@@ -95,21 +92,19 @@ end = struct
         let open Dune_lang.Syntax.Version.Infix in
         if dune_syntax >= check_valid_name_version
         then
-          Option.iter
-            names
-            ~f:
-              (List.iter ~f:(fun name ->
-                 ignore
-                   (Module_name.of_string_allow_invalid name
-                    |> Module_name.Unchecked.validate_exn
-                    : Module_name.t)));
+          Option.iter names ~f:(fun names ->
+            Nonempty_list.iter names ~f:(fun name ->
+              ignore
+                (Module_name.of_string_allow_invalid name
+                 |> Module_name.Unchecked.validate_exn
+                 : Module_name.t)));
         match names, public_names with
         | Some names, _ -> names
         | None, Some public_names ->
           if dune_syntax >= allow_omit_names_version
           then (
             let check_names = dune_syntax >= check_valid_name_version in
-            List.map public_names ~f:(fun (loc, p) ->
+            Nonempty_list.map public_names ~f:(fun (loc, p) ->
               match p, check_names with
               | None, _ ->
                 User_error.raise ~loc [ Pp.text "This executable must have a name field" ]
@@ -150,14 +145,14 @@ end = struct
               ~loc
               [ Pp.textf "field %s is missing" (pluralize ~multi "name") ]
       in
-      Nonempty_list.of_list_exn names
+      names
     in
     let public =
       match package, public_names with
       | None, None -> None
       | Some (_loc, package), Some public_names -> Some { package; public_names }
       | None, Some public_names ->
-        if List.for_all public_names ~f:(fun (_, x) -> Option.is_none x)
+        if Nonempty_list.for_all public_names ~f:(fun (_, x) -> Option.is_none x)
         then None
         else
           Some
@@ -179,24 +174,18 @@ end = struct
   let install_conf t ~ext ~enabled_if ~dir =
     Option.map t.public ~f:(fun { package; public_names } ->
       let files =
-        List.map2
-          (Nonempty_list.to_list t.names)
-          public_names
-          ~f:(fun (locn, name) (locp, pub) ->
-            Option.map pub ~f:(fun pub ->
-              Install_entry.File.of_file_binding
-                (File_binding.Unexpanded.make
-                   ~src:(locn, name ^ Filename.Extension.to_string ext)
-                   ~dst:(locp, pub)
-                   ~dune_syntax:t.dune_syntax
-                   ~dir:(Some dir))))
+        Nonempty_list.map2 t.names public_names ~f:(fun (locn, name) (locp, pub) ->
+          Option.map pub ~f:(fun pub ->
+            Install_entry.File.of_file_binding
+              (File_binding.Unexpanded.make
+                 ~src:(locn, name ^ Filename.Extension.to_string ext)
+                 ~dst:(locp, pub)
+                 ~dune_syntax:t.dune_syntax
+                 ~dir:(Some dir))))
+        |> Nonempty_list.to_list
         |> List.filter_opt
       in
-      let loc =
-        match public_names with
-        | [] -> assert false
-        | (loc, _) :: _ -> loc
-      in
+      let loc, _ = Nonempty_list.hd public_names in
       { Install_conf.section = loc, Section Bin
       ; files
       ; dirs = []

--- a/src/dune_rules/stanzas/tests.ml
+++ b/src/dune_rules/stanzas/tests.ml
@@ -58,7 +58,7 @@ let gen_parse names =
             ; modes
             ; optional = false
             ; buildable
-            ; names = Nonempty_list.of_list_exn names
+            ; names
             ; public_names = None
             ; package = None
             ; promote = None
@@ -78,4 +78,7 @@ let gen_parse names =
 ;;
 
 let multi = gen_parse (field "names" (repeat1 (located string)))
-let single = gen_parse (field "name" (located string) >>| List.singleton)
+
+let single =
+  gen_parse (field "name" (located string) >>| fun name -> Nonempty_list.[ name ])
+;;

--- a/src/dune_sexp/decoder.ml
+++ b/src/dune_sexp/decoder.ml
@@ -764,7 +764,7 @@ and keyword : string -> values context -> values -> unit * values =
 let repeat1 p =
   let+ x = p
   and+ xs = repeat p in
-  x :: xs
+  Nonempty_list.(x :: xs)
 ;;
 
 let parse t context sexp =

--- a/src/dune_sexp/decoder.mli
+++ b/src/dune_sexp/decoder.mli
@@ -140,7 +140,7 @@ val kind : (Kind.t, _) parser
 val repeat : 'a t -> 'a list t
 
 (** Like [repeat] but the list of elements must be non-empty. *)
-val repeat1 : 'a t -> 'a list t
+val repeat1 : 'a t -> 'a Nonempty_list.t t
 
 (** Capture the rest of the input for later parsing. *)
 val capture : ('a t -> 'a) t

--- a/test/expect-tests/dune_sexp/dune_sexp_tests.ml
+++ b/test/expect-tests/dune_sexp/dune_sexp_tests.ml
@@ -29,6 +29,22 @@ let test_bytes_hex ?check value =
   | None -> print_endline "hex value must not have letters"
 ;;
 
+let%expect_test "repeat1 returns a nonempty list" =
+  let values =
+    List.map [ "one"; "two" ] ~f:(Dune_sexp.Ast.atom_or_quoted_string Loc.none)
+  in
+  let value = Dune_sexp.Ast.List (Loc.none, values) in
+  let decoder = Dune_sexp.Decoder.(enter (repeat1 string)) in
+  let values : string Nonempty_list.t =
+    Dune_sexp.Decoder.parse decoder Univ_map.empty value
+  in
+  Nonempty_list.iter values ~f:print_endline;
+  [%expect
+    {|
+    one
+    two |}]
+;;
+
 (* Test parsing of integers. *)
 
 let%expect_test "parsing no suffix" =


### PR DESCRIPTION
Return Nonempty_list.t from repeat1 and propagate the invariant through executable and test name decoding.