### PR TITLE
refactor(merlin): retain file configuration metadata

### DIFF
--- a/src/dune_rules/merlin/merlin.ml
+++ b/src/dune_rules/merlin/merlin.ml
@@ -107,7 +107,10 @@ module Processed = struct
     { opens : Module_name.t list
     ; module_ : Module.t
     ; reader : string Nonempty_list.t option
+    ; kind : Ml_kind.t
     }
+
+  let ml_kind_repr = Repr.view Repr.string ~to_:Ml_kind.to_string
 
   let module_config_repr =
     Repr.record
@@ -118,14 +121,36 @@ module Processed = struct
           "reader"
           (Repr.option (Repr.view (Repr.list Repr.string) ~to_:Nonempty_list.to_list))
           ~get:(fun t -> t.reader)
+      ; Repr.field "kind" ml_kind_repr ~get:(fun t -> t.kind)
+      ]
+  ;;
+
+  type per_file_config =
+    { exact : module_config Path.Build.Map.t
+    ; without_extension : module_config list Path.Build.Map.t
+    }
+
+  let per_file_config_repr =
+    Repr.record
+      "merlin-per-file-config"
+      [ Repr.field
+          "exact"
+          (Repr.abstract (Path.Build.Map.to_dyn (Repr.to_dyn module_config_repr)))
+          ~get:(fun t -> t.exact)
+      ; Repr.field
+          "without_extension"
+          (Repr.abstract
+             (Path.Build.Map.to_dyn (Dyn.list (Repr.to_dyn module_config_repr))))
+          ~get:(fun t -> t.without_extension)
       ]
   ;;
 
   (* ...but modules can have different preprocessing specifications*)
   type configuration =
     { config : config
-    ; per_file_config : module_config Path.Build.Map.t
+    ; per_file_config : per_file_config
     ; pp_config : pp_flag option Module_name.Per_item.t
+    ; for_ : Compilation_mode.t
     }
 
   type t = configuration Nonempty_list.t
@@ -165,14 +190,13 @@ module Processed = struct
     Repr.record
       "merlin-processed"
       [ Repr.field "config" config_repr ~get:(fun t -> t.config)
-      ; Repr.field
-          "per_file_config"
-          (Repr.abstract (Path.Build.Map.to_dyn (Repr.to_dyn module_config_repr)))
-          ~get:(fun t -> t.per_file_config)
+      ; Repr.field "per_file_config" per_file_config_repr ~get:(fun t ->
+          t.per_file_config)
       ; Repr.field
           "pp_config"
           (Module_name.Per_item.repr (Repr.option pp_flag_repr))
           ~get:(fun t -> t.pp_config)
+      ; Repr.field "for_" Compilation_mode.repr ~get:(fun t -> t.for_)
       ]
   ;;
 
@@ -184,7 +208,7 @@ module Processed = struct
 
     let name = "merlin-conf"
     let sharing = false
-    let version = 10
+    let version = 11
 
     let repr =
       Repr.view Repr.string ~to_:(fun _ -> "Use [dune ocaml dump-dot-merlin] instead")
@@ -395,10 +419,45 @@ module Processed = struct
     | Exact_or_copy
     | Without_extension
 
-  let get_configuration { per_file_config; pp_config; config } ~file =
+  type source_kind =
+    | Implementation
+    | Interface
+
+  type file_configuration =
+    { mode : Compilation_mode.t
+    ; is_default : bool
+    ; kind : source_kind
+    ; counterpart : Path.t option
+    ; directives : Sexp.t
+    }
+
+  let select_without_extension candidates ~file =
+    let extension = Path.Build.extension file |> Filename.Extension.Or_empty.to_string in
+    let matching_extension =
+      List.filter candidates ~f:(fun { module_; kind; opens = _; reader = _ } ->
+        match Module.source_without_pp module_ ~ml_kind:kind with
+        | None -> false
+        | Some source ->
+          String.equal
+            extension
+            (Path.extension source |> Filename.Extension.Or_empty.to_string))
+    in
+    match matching_extension with
+    | [ candidate ] -> Some candidate
+    | [] ->
+      (match candidates with
+       | [ candidate ] -> Some candidate
+       | [] | _ :: _ :: _ -> None)
+    | _ :: _ :: _ -> None
+  ;;
+
+  let get_configuration
+        { per_file_config = { exact; without_extension }; pp_config; config; for_ = _ }
+        ~file
+    =
     let open Option.O in
-    let+ match_kind, { module_; opens; reader } =
-      let find file = Path.Build.Map.find per_file_config file in
+    let+ match_kind, ({ module_; opens; reader; kind = _ } as module_config) =
+      let find file = Path.Build.Map.find exact file in
       match find file with
       | Some config -> Some (Exact_or_copy, config)
       | None ->
@@ -413,42 +472,91 @@ module Processed = struct
               This is too rough but, really, preprocessors should emit copy
               line directives instead and then Dune should have the database
               similar to Copy_line_directive to handle this. *)
-           Path.Build.Map.find per_file_config (remove_extension file)
+           Path.Build.Map.find without_extension (remove_extension file)
+           >>= select_without_extension ~file
            |> Option.map ~f:(fun config -> Without_extension, config))
     in
     let pp = Module_name.Per_item.get pp_config (Module.name module_) in
     let unit_name = Module_name.Unique.to_string (Module.obj_name module_) in
-    match_kind, to_sexp ~unit_name ~opens ~pp ~reader config
+    match_kind, module_config, to_sexp ~unit_name ~opens ~pp ~reader config
   ;;
 
-  let configurations =
+  let matching_configurations =
     let rec loop configurations ~file ~exact ~without_extension =
       match configurations with
       | [] ->
         (match exact with
          | _ :: _ -> List.rev exact
          | [] -> List.rev without_extension)
-        |> Nonempty_list.of_list
-      | configuration :: configurations ->
+      | (is_default, configuration) :: configurations ->
         (match get_configuration configuration ~file with
          | None -> loop configurations ~file ~exact ~without_extension
-         | Some (Exact_or_copy, directives) ->
-           loop configurations ~file ~exact:(directives :: exact) ~without_extension
-         | Some (Without_extension, directives) ->
+         | Some (Exact_or_copy, module_config, directives) ->
+           let match_ = is_default, configuration, module_config, directives in
+           loop configurations ~file ~exact:(match_ :: exact) ~without_extension
+         | Some (Without_extension, module_config, directives) ->
+           let match_ = is_default, configuration, module_config, directives in
            loop
              configurations
              ~file
              ~exact
-             ~without_extension:(directives :: without_extension))
+             ~without_extension:(match_ :: without_extension))
     in
-    fun t ~file -> loop (Nonempty_list.to_list t) ~file ~exact:[] ~without_extension:[]
+    fun (default :: alternatives : t) ~file ->
+      let configurations =
+        (true, default)
+        :: List.map alternatives ~f:(fun configuration -> false, configuration)
+      in
+      loop configurations ~file ~exact:[] ~without_extension:[]
   ;;
 
-  let get t ~file = Option.map (configurations t ~file) ~f:Nonempty_list.hd
+  let configurations t ~file =
+    matching_configurations t ~file
+    |> List.map
+         ~f:
+           (fun
+             ( is_default
+             , { for_; config = _; per_file_config = _; pp_config = _ }
+             , { module_; kind; opens = _; reader = _ }
+             , directives )
+           ->
+           let counterpart_kind =
+             match kind with
+             | Ml_kind.Impl -> Ml_kind.Intf
+             | Intf -> Ml_kind.Impl
+           in
+           let counterpart =
+             Module.source_without_pp module_ ~ml_kind:counterpart_kind
+             |> Option.map ~f:Path.drop_optional_build_context
+           in
+           let kind =
+             match kind with
+             | Ml_kind.Impl -> Implementation
+             | Intf -> Interface
+           in
+           { mode = for_; is_default; kind; counterpart; directives })
+    |> Nonempty_list.of_list
+  ;;
 
-  let dump_entries { per_file_config; pp_config; config } : Dump_entry.t list =
-    Path.Build.Map.to_list per_file_config
-    |> List.map ~f:(fun (source_path, { module_; opens; reader }) ->
+  let get t ~file =
+    Option.map (configurations t ~file) ~f:(fun configurations ->
+      (Nonempty_list.hd configurations).directives)
+  ;;
+
+  let dump_entries
+        { per_file_config = { exact; without_extension }; pp_config; config; for_ = _ }
+    : Dump_entry.t list
+    =
+    let without_extension =
+      Path.Build.Map.to_list without_extension
+      |> List.filter_map ~f:(fun (path, configurations) ->
+        Option.map (List.hd_opt configurations) ~f:(fun configuration ->
+          path, configuration))
+    in
+    Path.Build.Map.to_list exact @ without_extension
+    |> Path.Build.Map.of_list_reduce ~f:(fun existing _ -> existing)
+    |> Path.Build.Map.to_list
+    |> List.map ~f:(fun (source_path, { module_; opens; reader; kind = _ }) ->
       let module_name = Module.name module_ in
       let unit_name = Module_name.Unique.to_string (Module.obj_name module_) in
       let pp = Module_name.Per_item.get pp_config module_name in
@@ -542,6 +650,7 @@ module Processed = struct
               , acc_indexes )
               { per_file_config = _
               ; pp_config
+              ; for_ = _
               ; config =
                   { stdlib_dir = _
                   ; source_root = _
@@ -882,30 +991,36 @@ module Unprocessed = struct
       ; parameters
       }
     and+ pp_config = pp_config t context ~expander in
-    let per_file_config =
+    let exact, without_extension =
       (* And copy for each module the resulting pp flags *)
       modules
       |> Modules.With_vlib.drop_vlib
-      |> Modules.fold ~init:[] ~f:(fun m init ->
-        Module.sources_without_pp m
-        |> Path.Build.Set.of_list_map ~f:(fun src -> Path.as_in_build_dir_exn src)
-        |> Path.Build.Set.fold ~init ~f:(fun src acc ->
-          let config =
-            { Processed.module_ = Module.set_pp m None
-            ; opens = Modules.With_vlib.local_open modules m
-            ; reader =
-                String.Map.find
-                  readers
-                  (Filename.Extension.Or_empty.to_string (Path.Build.extension src))
-            }
-          in
-          (* we add the config with and without the extension, the latter is
-             needed for a fallback in this file's [get] function. *)
-          let src_without_extension = remove_extension src in
-          (src, config) :: (src_without_extension, config) :: acc))
-      |> Path.Build.Map.of_list_reduce ~f:(fun existing _ -> existing)
+      |> Modules.fold ~init:([], []) ~f:(fun m init ->
+        List.fold_left Ml_kind.all ~init ~f:(fun (exact, without_extension) kind ->
+          match Module.source_without_pp m ~ml_kind:kind with
+          | None -> exact, without_extension
+          | Some source ->
+            let source = Path.as_in_build_dir_exn source in
+            let config =
+              { Processed.module_ = Module.set_pp m None
+              ; opens = Modules.With_vlib.local_open modules m
+              ; reader =
+                  String.Map.find
+                    readers
+                    (Filename.Extension.Or_empty.to_string (Path.Build.extension source))
+              ; kind
+              }
+            in
+            ( (source, config) :: exact
+            , (remove_extension source, config) :: without_extension )))
     in
-    { Processed.pp_config; config; per_file_config }
+    let per_file_config =
+      { Processed.exact =
+          Path.Build.Map.of_list_reduce exact ~f:(fun existing _ -> existing)
+      ; without_extension = Path.Build.Map.of_list_multi without_extension
+      }
+    in
+    { Processed.pp_config; config; per_file_config; for_ = t.config.for_ }
   ;;
 end
 

--- a/src/dune_rules/merlin/merlin.mli
+++ b/src/dune_rules/merlin/merlin.mli
@@ -34,6 +34,18 @@ module Processed : sig
   val pp_args : pp_flag -> string
   val load_file : Path.t -> (t, string) result
 
+  type source_kind =
+    | Implementation
+    | Interface
+
+  type file_configuration =
+    { mode : Compilation_mode.t
+    ; is_default : bool
+    ; kind : source_kind
+    ; counterpart : Path.t option
+    ; directives : Sexp.t
+    }
+
   (** [print_file path] reads the configuration at path [path] and print it as a
       s-expression *)
   val print_file : Path.t -> unit
@@ -45,6 +57,7 @@ module Processed : sig
   val print_generic_dot_merlin : Path.t list -> unit
 
   val get : t -> file:Path.Build.t -> Sexp.t option
+  val configurations : t -> file:Path.Build.t -> file_configuration Nonempty_list.t option
 end
 
 val make


### PR DESCRIPTION
Persist compilation mode and source-kind metadata in Merlin configurations, and expose a typed plural lookup API.

First Dune slice for single-context editor support, following ocaml/dune#16194.