### PR TITLE
refactor(exe): reuse executable project

### DIFF
--- a/src/dune_rules/exe_rules.ml
+++ b/src/dune_rules/exe_rules.ml
@@ -348,7 +348,7 @@ let executables_rules
       ~obj_dir
       ~preprocess:
         (Preprocess.Per_module.without_instrumentation exes.buildable.preprocess.config)
-      ~dialects:(Dune_project.dialects (Scope.project scope))
+      ~dialects:(Dune_project.dialects project)
       ~ident:(Merlin_ident.for_exe_target (Executables.exe_target exes))
       ~for_
       ~parameters:(Resolve.return [])


### PR DESCRIPTION
Reuse the executable rule's project when constructing its Merlin configuration.