### PR TITLE
refactor(compilation-context): reuse construction inputs

### DIFF
--- a/src/dune_rules/compilation_context.ml
+++ b/src/dune_rules/compilation_context.ml
@@ -175,6 +175,7 @@ let create
   =
   let project = Scope.project scope in
   let context = Super_context.context super_context in
+  let dir = Obj_dir.dir obj_dir in
   let* ocaml = Context.ocaml context in
   let direct_requires, hidden_requires =
     match Dune_project.implicit_transitive_deps project ocaml.version with
@@ -209,7 +210,7 @@ let create
   in
   let+ dep_graphs =
     Dep_rules.rules
-      ~dir:(Obj_dir.dir obj_dir)
+      ~dir
       ~sandbox
       ~obj_dir
       ~sctx:super_context
@@ -217,14 +218,11 @@ let create
       ~modules
       ~for_
   and+ bin_annot =
-    Memo.Option.value bin_annot ~default:(fun () ->
-      Env_stanza_db.bin_annot ~dir:(Obj_dir.dir obj_dir))
+    Memo.Option.value bin_annot ~default:(fun () -> Env_stanza_db.bin_annot ~dir)
   and+ bin_annot_cms =
-    Memo.Option.value bin_annot_cms ~default:(fun () ->
-      Env_stanza_db.bin_annot_cms ~dir:(Obj_dir.dir obj_dir))
+    Memo.Option.value bin_annot_cms ~default:(fun () -> Env_stanza_db.bin_annot_cms ~dir)
   and+ cms_cmt_dependency =
     Memo.Option.value cms_cmt_dependency ~default:(fun () ->
-      let context = Super_context.context super_context in
       Memo.return (Context.cms_cmt_dependency context))
   in
   { super_context


### PR DESCRIPTION
Reuse the context and object directory already derived while constructing a compilation context.