### PR TITLE
refactor(ocaml-index): reuse context build directory

### DIFF
--- a/src/dune_rules/merlin/ocaml_index.ml
+++ b/src/dune_rules/merlin/ocaml_index.ml
@@ -150,14 +150,12 @@ let context_indexes =
         "indixes"
         ~input:(module Input)
         (fun (ctx, for_) ->
+           let build_dir = Context.build_dir ctx in
            Context.name ctx
            |> Dune_load.dune_files
            >>| Dune_file.fold_static_stanzas ~init:[] ~f:(fun dune_file stanza acc ->
              let obj =
-               let dir =
-                 let build_dir = Context.build_dir ctx in
-                 Path.Build.append_source build_dir (Dune_file.dir dune_file)
-               in
+               let dir = Path.Build.append_source build_dir (Dune_file.dir dune_file) in
                match Stanza.repr stanza with
                | Executables.T exes | Tests.T { exes; _ } ->
                  Some (Executables.obj_dir ~dir exes)


### PR DESCRIPTION
Resolve the context build directory once while collecting OCaml index entries.