### PR TITLE
refactor(rules): use local library information

### DIFF
--- a/src/dune_rules/odoc/odoc_new.ml
+++ b/src/dune_rules/odoc/odoc_new.ml
@@ -21,7 +21,7 @@ let stdlib_lib ctx =
 let lib_equal l1 l2 = Lib.compare l1 l2 |> Ordering.is_eq
 
 let is_public lib =
-  match Lib.Local.to_lib lib |> Lib.info |> Lib_info.status with
+  match Lib.Local.info lib |> Lib_info.status with
   | Installed_private -> false
   | Installed -> true
   | Public _ -> true

--- a/src/dune_rules/scope.ml
+++ b/src/dune_rules/scope.ml
@@ -452,7 +452,7 @@ module DB = struct
     ;;
 
     let loc = function
-      | Library lib -> Lib.Local.to_lib lib |> Lib.info |> Lib_info.loc
+      | Library lib -> Lib.Local.info lib |> Lib_info.loc
       | Deprecated_library_name { old_name = old_public_name, _; _ } ->
         Public_lib.loc old_public_name
     ;;


### PR DESCRIPTION
Use local-library metadata directly instead of converting through generic library values.