### PR TITLE
refactor(packages): share documentation directory derivation

### DIFF
--- a/src/dune_rules/packages.ml
+++ b/src/dune_rules/packages.ml
@@ -10,22 +10,16 @@ let mlds_by_package_def =
     ~input:(module Super_context.As_memo_key)
     (fun sctx ->
        let ctx = Super_context.context sctx in
+       let build_dir = Context.build_dir ctx in
        Context.name ctx
        |> Dune_load.dune_files
        >>= Memo.parallel_map ~f:(fun dune_file ->
+         let dir = Path.Build.append_source build_dir (Dune_file.dir dune_file) in
          Dune_file.stanzas dune_file
          >>= Memo.parallel_map ~f:(fun stanza ->
            match Stanza.repr stanza with
            | Documentation.T stanza ->
-             let+ mlds =
-               (let dir =
-                  Path.Build.append_source
-                    (Context.build_dir ctx)
-                    (Dune_file.dir dune_file)
-                in
-                Dir_contents.get sctx ~dir)
-               >>= Dir_contents.mlds ~stanza
-             in
+             let+ mlds = Dir_contents.get sctx ~dir >>= Dir_contents.mlds ~stanza in
              let name = Package.name stanza.package in
              Some (name, mlds)
            | _ -> Memo.return None)


### PR DESCRIPTION
Derive context and dune-file documentation directories once while collecting package mlds.