### PR TITLE
refactor(opam): reuse context projections

### DIFF
--- a/src/dune_rules/opam_create.ml
+++ b/src/dune_rules/opam_create.ml
@@ -507,17 +507,13 @@ let add_opam_file_rules sctx project =
 let add_rules sctx project =
   Memo.when_ (Dune_project.generate_opam_files project) (fun () ->
     let context = Super_context.context sctx in
+    let build_context = Context.build_context context in
+    let profile = Context.profile context in
     let packages = Dune_project.packages project in
     Memo.parallel_iter_seq
       (Dune_lang.Package_name.Map.to_seq packages)
       ~f:(fun (_name, (pkg : Package.t)) ->
-        let* () =
-          add_alias_rule
-            (Context.build_context context)
-            ~profile:(Context.profile context)
-            ~project
-            ~pkg
-        in
+        let* () = add_alias_rule build_context ~profile ~project ~pkg in
         match Dune_project.opam_file_location project with
         | `Inside_opam_directory -> Memo.return ()
         | `Relative_to_project -> add_opam_file_rule sctx ~project ~pkg))


### PR DESCRIPTION
Derive the build context and profile once while generating package opam rules.