### PR TITLE
refactor(odoc): reuse external library name

### DIFF
--- a/src/dune_rules/odoc/odoc_new.ml
+++ b/src/dune_rules/odoc/odoc_new.ml
@@ -185,7 +185,7 @@ module Index = struct
       of_external_loc maps loc
     with
     | Some loc -> loc
-    | None -> [ Sub_dir (Lib_name.to_string (Lib.name lib)); Top_dir Other ]
+    | None -> [ Sub_dir (Lib_name.to_string name); Top_dir Other ]
   ;;
 
   let of_pkg maps pkg =


### PR DESCRIPTION
Reuse the external library name when constructing its fallback documentation location.