### PR TITLE
refactor(ocaml-index): use context build directory

### DIFF
--- a/src/dune_rules/merlin/ocaml_index.ml
+++ b/src/dune_rules/merlin/ocaml_index.ml
@@ -90,10 +90,7 @@ let cctx_rules cctx =
       Command.Args.Hidden_deps deps
     in
     let context_dir =
-      Compilation_context.context cctx
-      |> Context.name
-      |> Context_name.build_dir
-      |> Path.build
+      Compilation_context.context cctx |> Context.build_dir |> Path.build
     in
     (* Indexation also depends on the current stanza's modules *)
     let modules_deps =


### PR DESCRIPTION
Use Context.build_dir directly for the ocaml-index working directory.