### PR TITLE
refactor(jsoo): reuse library metadata for archive paths

### DIFF
--- a/src/dune_rules/jsoo/jsoo_rules.ml
+++ b/src/dune_rules/jsoo/jsoo_rules.ml
@@ -692,7 +692,7 @@ let jsoo_archives ~mode ctx config lib =
         (in_build_dir
            ctx
            ~config
-           [ Lib_name.to_string (Lib.name lib)
+           [ Lib_name.to_string (Lib_info.name info)
            ; with_js_ext ~mode (Path.basename archive |> Filename.to_string)
            ]))
 ;;


### PR DESCRIPTION
Use already-resolved library metadata when deriving installed js_of_ocaml archive paths.