### PR TITLE
prototype(melange): add explicit cmi artifact pform

### DIFF
--- a/doc/advanced/variables-artifacts.rst
+++ b/doc/advanced/variables-artifacts.rst
@@ -23,6 +23,11 @@ interpreted relative to the current directory:
 
 - ``cmi:<path>`` expands to the compiled interface for the specified module.
 
+- ``melange.cmi:<path>`` expands to the Melange compiled interface for the
+  specified module, including when that module is also selected for OCaml.
+
+  .. versionadded:: 3.25
+
 - ``cmj:<path>`` expands to the Melange compiled module for the specified
   module.
 

--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -272,9 +272,15 @@ module Artifact = struct
     | Lib mode -> Mode.compiled_lib_ext mode
   ;;
 
+  let name = function
+    | Mod (Melange Cmi) -> "melange.cmi"
+    | artifact -> ext artifact |> Filename.Extension.drop_dot
+  ;;
+
   let all =
     Mod Cmt
     :: Mod Cmti
+    :: Mod (Melange Cmi)
     :: Mod (Melange Cmj)
     :: (List.map ~f:(fun kind -> Mod (Cm_kind kind)) Cm_kind.all
         @ List.map ~f:(fun mode -> Lib mode) Mode.all)
@@ -430,7 +436,7 @@ module Macro = struct
     | Pkg -> Ok "pkg"
     | Pkg_self -> Ok "pkg-self"
     | Ppx -> Ok "ppx"
-    | Artifact a -> Ok (Artifact.ext a |> Filename.Extension.drop_dot)
+    | Artifact a -> Ok (Artifact.name a)
   ;;
 end
 
@@ -667,7 +673,7 @@ module Env = struct
     let macros =
       let macro (x : Macro.t) = No_info x in
       let artifact x =
-        let name = Artifact.ext x |> Filename.Extension.drop_dot in
+        let name = Artifact.name x in
         let version =
           match x with
           | Mod Cmt | Mod Cmti -> 3, 21

--- a/test/blackbox-tests/test-cases/melange/mixed-module-artifact-pforms.t
+++ b/test/blackbox-tests/test-cases/melange/mixed-module-artifact-pforms.t
@@ -35,6 +35,28 @@ artifact, like Merlin does.
     ]
   }
 
+The melange.cmi variable explicitly selects the Melange artifact, including
+when the module is selected in both modes.
+
+  $ dune build '%{melange.cmi:lib/common}'
+  $ dune trace cat | jq 'select(.name == "targets") | .args'
+  {
+    "targets": [
+      "_build/default/lib/.foo.objs/melange/foo__Common.cmi"
+    ]
+  }
+
+It also selects modules that are only compiled with Melange.
+
+  $ dune build '%{melange.cmi:lib/melange_only}'
+
+It does not fall back to the OCaml module set.
+
+  $ dune build '%{melange.cmi:lib/ocaml_only}'
+  File "command line", line 1, characters 0-29:
+  Error: Module Ocaml_only does not exist.
+  [1]
+
 The cmj variable always selects the Melange artifact.
 
   $ dune build '%{cmj:lib/common}'
@@ -65,3 +87,36 @@ OCaml-specific artifact variables do not fall back to the Melange module set.
   File "command line", line 1, characters 0-23:
   Error: Module Melange_only does not exist.
   [1]
+
+The melange.cmi variable is available in dune files since version 3.25 of the
+Dune language.
+
+  $ mkdir version-gate
+  $ cat > version-gate/dune-project <<'EOF'
+  > (lang dune 3.24)
+  > (using melange 1.0)
+  > EOF
+  $ cat > version-gate/dune <<'EOF'
+  > (library
+  >  (name foo)
+  >  (modes melange))
+  > (alias
+  >  (name explicit-cmi)
+  >  (deps %{melange.cmi:foo}))
+  > EOF
+  $ touch version-gate/foo.ml
+  $ dune build --root=version-gate @explicit-cmi
+  Entering directory 'version-gate'
+  File "dune", line 6, characters 7-25:
+  6 |  (deps %{melange.cmi:foo}))
+             ^^^^^^^^^^^^^^^^^^
+  Error: %{melange.cmi:..} is only available since version 3.25 of the dune
+  language. Please update your dune-project file to have (lang dune 3.25).
+  Leaving directory 'version-gate'
+  [1]
+
+  $ cat > version-gate/dune-project <<'EOF'
+  > (lang dune 3.25)
+  > (using melange 1.0)
+  > EOF
+  $ dune build --root=version-gate @explicit-cmi


### PR DESCRIPTION
Prototype %{melange.cmi:...} as an explicit selector for Melange interface artifacts, reusing the grouped Melange artifact kind.

Stacked on #186 and #187.