### PR TITLE
feat(melange): add cmj artifact pform

### DIFF
--- a/doc/changes/added/187.md
+++ b/doc/changes/added/187.md
@@ -1,0 +1,2 @@
+- Add the ``%{cmj:<module>}`` variable for referring to Melange compiled module
+  artifacts. (#187, @anmonteiro)

--- a/doc/changes/fixed/16339.md
+++ b/doc/changes/fixed/16339.md
@@ -1,0 +1,3 @@
+- Resolve ``%{cmi:...}``, ``%{cmt:...}``, and ``%{cmti:...}`` against Melange
+  module sets when no OCaml module is selected, while preferring OCaml for
+  modules selected in both modes. (#16339, @anmonteiro)

--- a/src/dune_lang/melange.ml
+++ b/src/dune_lang/melange.ml
@@ -5,6 +5,13 @@ module Cm_kind = struct
     | Cmi
     | Cmj
 
+  let compare x y =
+    match x, y with
+    | Cmi, Cmi | Cmj, Cmj -> Eq
+    | Cmi, Cmj -> Lt
+    | Cmj, Cmi -> Gt
+  ;;
+
   let source = function
     | Cmi -> Ocaml.Ml_kind.Intf
     | Cmj -> Impl

--- a/src/dune_lang/melange.mli
+++ b/src/dune_lang/melange.mli
@@ -5,6 +5,7 @@ module Cm_kind : sig
     | Cmi
     | Cmj
 
+  val compare : t -> t -> Ordering.t
   val source : t -> Ocaml.Ml_kind.t
   val ext : t -> Filename.Extension.t
   val to_dyn : t -> Dyn.t

--- a/src/dune_lang/pform.ml
+++ b/src/dune_lang/pform.ml
@@ -225,6 +225,7 @@ module Artifact = struct
 
   type mod_ =
     | Cm_kind of Ocaml.Cm_kind.t
+    | Melange of Melange.Cm_kind.t
     | Cmt
     | Cmti
 
@@ -232,6 +233,7 @@ module Artifact = struct
     let open Dyn in
     function
     | Cm_kind x -> Ocaml.Cm_kind.to_dyn x
+    | Melange x -> variant "Melange" [ Melange.Cm_kind.to_dyn x ]
     | Cmt -> variant "Cmt" []
     | Cmti -> variant "Cmti" []
   ;;
@@ -245,6 +247,9 @@ module Artifact = struct
     | Cm_kind x, Cm_kind y -> Ocaml.Cm_kind.compare x y
     | Cm_kind _, _ -> Lt
     | _, Cm_kind _ -> Gt
+    | Melange x, Melange y -> Melange.Cm_kind.compare x y
+    | Melange _, _ -> Lt
+    | _, Melange _ -> Gt
     | Cmt, Cmt -> Eq
     | Cmt, _ -> Lt
     | _, Cmt -> Gt
@@ -263,12 +268,14 @@ module Artifact = struct
     | Mod Cmt -> Filename.Extension.cmt
     | Mod Cmti -> Filename.Extension.cmti
     | Mod (Cm_kind cm_kind) -> Cm_kind.ext cm_kind
+    | Mod (Melange cm_kind) -> Melange.Cm_kind.ext cm_kind
     | Lib mode -> Mode.compiled_lib_ext mode
   ;;
 
   let all =
     Mod Cmt
     :: Mod Cmti
+    :: Mod (Melange Cmj)
     :: (List.map ~f:(fun kind -> Mod (Cm_kind kind)) Cm_kind.all
         @ List.map ~f:(fun mode -> Lib mode) Mode.all)
   ;;
@@ -664,6 +671,7 @@ module Env = struct
         let version =
           match x with
           | Mod Cmt | Mod Cmti -> 3, 21
+          | Mod (Melange _) -> 3, 25
           | _ -> 2, 0
         in
         name, since ~version (Macro.Artifact x)

--- a/src/dune_lang/pform.mli
+++ b/src/dune_lang/pform.mli
@@ -105,6 +105,7 @@ end
 module Artifact : sig
   type mod_ =
     | Cm_kind of Ocaml.Cm_kind.t
+    | Melange of Melange.Cm_kind.t
     | Cmt
     | Cmti
 

--- a/src/dune_rules/artifacts_obj.ml
+++ b/src/dune_rules/artifacts_obj.ml
@@ -31,16 +31,18 @@ let module_source_path_without_extension m =
   |> Option.map ~f:(fun p -> fst (Path.Build.split_extension p))
 ;;
 
-let make ~dir ~expander ~lib_config ~libs ~exes ~melange_emits =
-  let+ libraries =
-    Memo.List.map libs ~f:(fun ((lib : Library.t), _, _) ->
-      let+ lib_config = lib_config in
+let make ~dir ~for_ ~expander ~lib_config ~libs ~exes ~melange_emits =
+  let+ lib_config = lib_config in
+  let libs =
+    List.map libs ~f:(fun ((lib : Library.t), modules, obj_dir) ->
       let name = Lib_name.of_local lib.name in
       let info =
         Library.to_lib_info lib ~expander:(Memo.return expander) ~dir ~lib_config
       in
-      name, info)
-    >>| Lib_name.Map.of_list_exn
+      name, info, modules, obj_dir)
+  in
+  let libraries =
+    List.map libs ~f:(fun (name, info, _, _) -> name, info) |> Lib_name.Map.of_list_exn
   in
   let modules =
     let by_path modules obj_dir =
@@ -50,11 +52,21 @@ let make ~dir ~expander ~lib_config ~libs ~exes ~melange_emits =
         | Some key -> Path.Build.Map.add_exn modules key (obj_dir, m))
     in
     let init =
-      List.fold_left exes ~init:Path.Build.Map.empty ~f:(fun modules (m, obj_dir) ->
-        by_path modules obj_dir m)
+      match for_ with
+      | Compilation_mode.Ocaml ->
+        List.fold_left exes ~init:Path.Build.Map.empty ~f:(fun modules (m, obj_dir) ->
+          by_path modules obj_dir m)
+      | Compilation_mode.Melange -> Path.Build.Map.empty
     in
-    List.fold_left libs ~init ~f:(fun modules (_, m, obj_dir) ->
-      by_path modules obj_dir m)
+    List.fold_left libs ~init ~f:(fun modules (_, info, m, obj_dir) ->
+      if
+        List.mem
+          (Compilation_mode.Set.of_lib_mode_set (Lib_info.modes info)
+           |> Compilation_mode.Set.to_list)
+          for_
+          ~equal:Compilation_mode.equal
+      then by_path modules obj_dir m
+      else modules)
   in
   let melange_emits =
     match Path.Build.Map.of_list melange_emits with

--- a/src/dune_rules/artifacts_obj.mli
+++ b/src/dune_rules/artifacts_obj.mli
@@ -6,6 +6,7 @@ val empty : t
 
 val make
   :  dir:Path.Build.t
+  -> for_:Compilation_mode.t
   -> expander:Expander0.t
   -> lib_config:Lib_config.t Memo.t
   -> libs:(Library.t * Modules.t * Path.Build.t Obj_dir.t) list

--- a/src/dune_rules/dir_contents.ml
+++ b/src/dune_rules/dir_contents.ml
@@ -518,9 +518,9 @@ let modules_of_lib sctx lib ~for_ =
 ;;
 
 let () =
-  Fdecl.set Expander.lookup_artifacts (fun ~dir ->
+  Fdecl.set Expander.lookup_artifacts (fun ~dir ~for_ ->
     let* t =
       Context.DB.by_dir dir >>| Context.name >>= Super_context.find_exn >>= Load.get ~dir
     in
-    Memo.Lazy.force t.ocaml >>= Ml_sources.artifacts)
+    ml t ~for_ >>= Ml_sources.artifacts)
 ;;

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -185,28 +185,51 @@ let expand_artifact ~source t artifact arg =
   let does_not_exist ~what name =
     User_error.raise ~loc [ Pp.textf "%s %s does not exist." what name ]
   in
-  let* artifacts =
+  let lookup_artifacts ~for_ =
     let lookup = Fdecl.get lookup_artifacts in
-    Action_builder.of_memo (lookup ~dir)
+    Action_builder.of_memo (lookup ~dir ~for_)
+  in
+  let lookup_module ~for_ =
+    let+ artifacts = lookup_artifacts ~for_ in
+    Artifacts_obj.lookup_module artifacts path
+    |> Option.map ~f:(fun (obj_dir, module_) -> for_, obj_dir, module_)
+  in
+  let lookup_module_ocaml_first () =
+    let* ocaml = lookup_module ~for_:Compilation_mode.Ocaml in
+    match ocaml with
+    | Some _ -> Action_builder.return ocaml
+    | None -> lookup_module ~for_:Compilation_mode.Melange
   in
   match artifact with
   | Pform.Artifact.Mod kind ->
-    (match Artifacts_obj.lookup_module artifacts path with
+    let* module_ =
+      match kind with
+      | Cm_kind (Cmo | Cmx) -> lookup_module ~for_:Compilation_mode.Ocaml
+      | Cm_kind Cmi | Cmt | Cmti -> lookup_module_ocaml_first ()
+    in
+    (match module_ with
      | None ->
        Module_name.of_string_allow_invalid (loc, Filename.to_string name)
        |> Module_name.Unchecked.allow_invalid
        |> Module_name.to_string
        |> does_not_exist ~what:"Module"
-     | Some (t, m) ->
+     | Some (for_, obj_dir, m) ->
+       let cmi_kind =
+         match for_ with
+         | Compilation_mode.Ocaml -> Lib_mode.Cm_kind.Ocaml Ocaml.Cm_kind.Cmi
+         | Compilation_mode.Melange -> Lib_mode.Cm_kind.Melange Melange.Cm_kind.Cmi
+       in
        (match
           match kind with
-          | Cm_kind kind -> Obj_dir.Module.cm_file t m ~kind:(Ocaml kind)
-          | Cmt -> Obj_dir.Module.cmt_file t m ~cm_kind:(Ocaml Cmi) ~ml_kind:Impl
-          | Cmti -> Some (Obj_dir.Module.cmti_file t m ~cm_kind:(Ocaml Cmi))
+          | Cm_kind Cmi -> Obj_dir.Module.cm_file obj_dir m ~kind:cmi_kind
+          | Cm_kind kind -> Obj_dir.Module.cm_file obj_dir m ~kind:(Ocaml kind)
+          | Cmt -> Obj_dir.Module.cmt_file obj_dir m ~cm_kind:cmi_kind ~ml_kind:Impl
+          | Cmti -> Some (Obj_dir.Module.cmti_file obj_dir m ~cm_kind:cmi_kind)
         with
         | None -> Action_builder.return [ Value.String "" ]
         | Some path -> dep (Path.build path)))
   | Lib mode ->
+    let* artifacts = lookup_artifacts ~for_:Compilation_mode.Ocaml in
     let name =
       Lib_name.parse_string_exn
         (Dune_lang.Template.Pform.loc source, Filename.to_string name)
@@ -229,7 +252,7 @@ let expand_melange_emit ~source t arg =
   then User_error.raise ~loc [ Pp.text "cannot escape the workspace root directory" ];
   let* artifacts =
     let lookup = Fdecl.get lookup_artifacts in
-    Action_builder.of_memo (lookup ~dir:stanza_dir)
+    Action_builder.of_memo (lookup ~dir:stanza_dir ~for_:Compilation_mode.Melange)
   in
   match Artifacts_obj.lookup_melange_emit artifacts target_dir with
   | None ->

--- a/src/dune_rules/expander.ml
+++ b/src/dune_rules/expander.ml
@@ -205,6 +205,7 @@ let expand_artifact ~source t artifact arg =
     let* module_ =
       match kind with
       | Cm_kind (Cmo | Cmx) -> lookup_module ~for_:Compilation_mode.Ocaml
+      | Melange _ -> lookup_module ~for_:Compilation_mode.Melange
       | Cm_kind Cmi | Cmt | Cmti -> lookup_module_ocaml_first ()
     in
     (match module_ with
@@ -223,6 +224,7 @@ let expand_artifact ~source t artifact arg =
           match kind with
           | Cm_kind Cmi -> Obj_dir.Module.cm_file obj_dir m ~kind:cmi_kind
           | Cm_kind kind -> Obj_dir.Module.cm_file obj_dir m ~kind:(Ocaml kind)
+          | Melange kind -> Obj_dir.Module.cm_file obj_dir m ~kind:(Melange kind)
           | Cmt -> Obj_dir.Module.cmt_file obj_dir m ~cm_kind:cmi_kind ~ml_kind:Impl
           | Cmti -> Some (Obj_dir.Module.cmti_file obj_dir m ~cm_kind:cmi_kind)
         with

--- a/src/dune_rules/expander.mli
+++ b/src/dune_rules/expander.mli
@@ -136,7 +136,8 @@ val foreign_flags
   : (dir:Path.Build.t -> string list Action_builder.t Foreign_language.Dict.t Memo.t)
       Fdecl.t
 
-val lookup_artifacts : (dir:Path.Build.t -> Artifacts_obj.t Memo.t) Fdecl.t
+val lookup_artifacts
+  : (dir:Path.Build.t -> for_:Compilation_mode.t -> Artifacts_obj.t Memo.t) Fdecl.t
 
 val resolve_pkg_install_file
   : (loc:Loc.t

--- a/src/dune_rules/ml_sources.ml
+++ b/src/dune_rules/ml_sources.ml
@@ -1417,6 +1417,7 @@ let make
       let { Source_file_dir.dir; _ } = Nonempty_list.hd dirs in
       Artifacts_obj.make
         ~dir
+        ~for_
         ~expander:(Expander.to_expander0 expander)
         ~lib_config
         ~libs

--- a/test/blackbox-tests/test-cases/melange/mixed-module-artifact-pforms.t
+++ b/test/blackbox-tests/test-cases/melange/mixed-module-artifact-pforms.t
@@ -35,6 +35,16 @@ artifact, like Merlin does.
     ]
   }
 
+The cmj variable always selects the Melange artifact.
+
+  $ dune build '%{cmj:lib/common}'
+  $ dune trace cat | jq 'select(.name == "targets") | .args'
+  {
+    "targets": [
+      "_build/default/lib/.foo.objs/melange/foo__Common.cmj"
+    ]
+  }
+
 The Melange-only module artifacts exist in the Melange object directory.
 
   $ dune build lib/.foo.objs/melange/foo__Melange_only.{cmi,cmt}

--- a/test/blackbox-tests/test-cases/melange/mixed-module-artifact-pforms.t
+++ b/test/blackbox-tests/test-cases/melange/mixed-module-artifact-pforms.t
@@ -39,14 +39,19 @@ The Melange-only module artifacts exist in the Melange object directory.
 
   $ dune build lib/.foo.objs/melange/foo__Melange_only.{cmi,cmt}
 
-Artifact variables do not find modules that are only in the Melange module
-set.
+Artifact variables fall back to the Melange module set when the module is not
+selected for OCaml.
 
   $ dune build '%{cmi:lib/melange_only}'
+  $ dune build '%{cmt:lib/melange_only}'
+
+OCaml-specific artifact variables do not fall back to the Melange module set.
+
+  $ dune build '%{cmo:lib/melange_only}'
   File "command line", line 1, characters 0-23:
   Error: Module Melange_only does not exist.
   [1]
-  $ dune build '%{cmt:lib/melange_only}'
+  $ dune build '%{cmx:lib/melange_only}'
   File "command line", line 1, characters 0-23:
   Error: Module Melange_only does not exist.
   [1]

--- a/test/blackbox-tests/test-cases/melange/module-artifact-pforms.t
+++ b/test/blackbox-tests/test-cases/melange/module-artifact-pforms.t
@@ -33,9 +33,42 @@ for a Melange-only library.
   $ dune build '%{cmt:foo}'
   $ dune build '%{cmti:foo}'
 
-The variable for Melange's compiled module artifact is not recognized.
+The cmj variable resolves Melange's compiled module artifact.
 
   $ dune build '%{cmj:foo}'
-  Usage: dune build [--help] [OPTION]… [TARGET]…
-  dune: TARGET… arguments: Unknown macro %{cmj:..}
+
+The cmj variable is available in dune files since Dune 3.25. CLI arguments use
+the latest language version, which is why the command above succeeds in this
+Dune 3.21 project.
+
+  $ mkdir cmj-version
+  $ cat > cmj-version/dune <<'EOF'
+  > (library
+  >  (name foo)
+  >  (modes melange))
+  > (rule
+  >  (alias artifact)
+  >  (action (echo %{cmj:foo})))
+  > EOF
+  $ echo 'let x = 42' > cmj-version/foo.ml
+
+  $ cat > cmj-version/dune-project <<'EOF'
+  > (lang dune 3.24)
+  > (using melange 1.0)
+  > EOF
+  $ dune build --root=cmj-version @artifact
+  Entering directory 'cmj-version'
+  File "dune", line 6, characters 15-25:
+  6 |  (action (echo %{cmj:foo})))
+                     ^^^^^^^^^^
+  Error: %{cmj:..} is only available since version 3.25 of the dune language.
+  Please update your dune-project file to have (lang dune 3.25).
+  Leaving directory 'cmj-version'
   [1]
+
+  $ cat > cmj-version/dune-project <<'EOF'
+  > (lang dune 3.25)
+  > (using melange 1.0)
+  > EOF
+  $ dune build --root=cmj-version @artifact
+  .foo.objs/melange/foo.cmj

--- a/test/blackbox-tests/test-cases/melange/module-artifact-pforms.t
+++ b/test/blackbox-tests/test-cases/melange/module-artifact-pforms.t
@@ -26,21 +26,12 @@ The Melange compiler produces all four module artifacts.
   _build/default/.foo.objs/melange/foo.cmt
   _build/default/.foo.objs/melange/foo.cmti
 
-The existing module artifact variables incorrectly resolve artifacts for a
-Melange-only library to the bytecode object directory.
+Module artifact variables resolve artifacts from the Melange object directory
+for a Melange-only library.
 
   $ dune build '%{cmi:foo}'
-  Error: No rule found for .foo.objs/byte/foo.cmi
-  -> required by %{cmi:foo} at command line:1
-  [1]
   $ dune build '%{cmt:foo}'
-  Error: No rule found for .foo.objs/byte/foo.cmt
-  -> required by %{cmt:foo} at command line:1
-  [1]
   $ dune build '%{cmti:foo}'
-  Error: No rule found for .foo.objs/byte/foo.cmti
-  -> required by %{cmti:foo} at command line:1
-  [1]
 
 The variable for Melange's compiled module artifact is not recognized.
 


### PR DESCRIPTION
Add %{cmj:...} using Melange.Cm_kind.t for module artifacts.

Split from and stacked on ocaml/dune#16339. Documentation remains in #186.